### PR TITLE
fixing wrong deserialization/serialization when crafting a tx.

### DIFF
--- a/.mocharc
+++ b/.mocharc
@@ -2,4 +2,5 @@
 --require source-map-support/register
 --full-trace
 --bail
+--timeout 6000
 src/**/*.spec.ts

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "rimraf": "^2.6.1",
     "source-map-support": "^0.4.15",
     "ts-node": "^3.3.0",
+    "tslint": "^5.6.0",
     "typedoc": "^0.7.1",
     "typedoc-plugin-external-module-name": "^1.0.9",
     "typescript": "^2.3.4"

--- a/src/api/TransactionApi.ts
+++ b/src/api/TransactionApi.ts
@@ -41,8 +41,7 @@ export default class TransactionApi {
 
         const tx = new Tx(data, this.http.network, params.passphrase, params.secondPassphrase);
         data = tx.generate();
-
-        const typedTx = deserialize(model.Transaction, serialize(data));
+        const typedTx = deserialize(model.Transaction, data);
 
         observer.next(typedTx);
         observer.complete();
@@ -72,7 +71,7 @@ export default class TransactionApi {
         tx.setAddress();
         data = tx.generate();
 
-        const typedTx = deserialize(model.Transaction, serialize(data));
+        const typedTx = deserialize(model.Transaction, data);
 
         observer.next(typedTx);
         observer.complete();
@@ -103,7 +102,7 @@ export default class TransactionApi {
         const tx = new Tx(data, this.http.network, params.passphrase, params.secondPassphrase);
         data = tx.generate();
 
-        const typedTx = deserialize(model.Transaction, serialize(data));
+        const typedTx = deserialize(model.Transaction, data);
 
         observer.next(typedTx);
         observer.complete();
@@ -129,7 +128,7 @@ export default class TransactionApi {
         tx.setAssetSignature();
         data = tx.generate();
 
-        const typedTx = deserialize(model.Transaction, serialize(data));
+        const typedTx = deserialize(model.Transaction, data);
 
         observer.next(typedTx);
         observer.complete();

--- a/src/api/test/TransactionApi.spec.ts
+++ b/src/api/test/TransactionApi.spec.ts
@@ -42,6 +42,22 @@ describe('TransactionApi', () => {
     });
   });
 
+  it('should create an instance of transaction with given parameters', () => {
+    return api.createTransaction({
+      amount: 100000000,
+      passphrase: 'my secret',
+      recipientId: address,
+      vendorField: 'Send transaction by ark-tsc',
+    }).forEach((transaction) => {
+      expect(transaction).to.be.instanceOf(Transaction);
+      expect(transaction.amount).to.be.eq(100000000);
+      expect(transaction.recipientId).to.be.eq(address);
+      expect(transaction.vendorField).to.be.eq('Send transaction by ark-tsc');
+      expect(transaction.type).to.be.eq(0);
+
+    });
+  });
+
   it('should create a instance of Transaction from createVote', () => {
     return api.createVote({
       delegatePublicKey: '021e6d971e5885a3147ddf1e45bf5c8d0887ad9fc659e24bdf95c2c9607e7e3fe8',


### PR DESCRIPTION
I was trying to use this lib when I noticed that any crafted tx was returning an instance of `model.Transaction` with all empty fields ('undefined'). 

That was because a `serialize` was called incorrectly on a plain object before deserialization.

I've also added a test that, before my modifications, was failing.

Cheers
