### PR TITLE
Bugfix/signature

### DIFF
--- a/src/api/TransactionApi.ts
+++ b/src/api/TransactionApi.ts
@@ -34,6 +34,7 @@ export default class TransactionApi {
         let data = <model.Transaction> {
           amount: params.amount,
           fee: fees.send,
+          timestamp: params.timestamp,
           recipientId: params.recipientId,
           type: model.TransactionType.SendArk,
           vendorField: params.vendorField,

--- a/src/api/test/TransactionApi.spec.ts
+++ b/src/api/test/TransactionApi.spec.ts
@@ -44,6 +44,19 @@ describe('TransactionApi', () => {
       });
     });
 
+    it('should correctly sign a tx with vendorField', () => {
+      return api.createTransaction({
+        amount: 10,
+        passphrase: 'mysecret',
+        timestamp: 1,
+        vendorField: 'hi from vekexasia',
+        recipientId: 'DRKaLgq8jKYQEdN2EJ7aGEh8hMDvMzd3CW',
+      }).forEach((transaction) => {
+        expect(transaction.signature).to.be.deep.eq('3044022035a591c9b8eb42732f1a87f6c535265fdc8015afd5105f1cf31012daeb3fffd50220705ac531bafc15d74ee263223c6346937c5fe31407c100cd732e8fd7780c8072');
+        expect(transaction.id).to.be.deep.eq('6bd6d69320efcf04d442b53034e07d3127905c353412d4a2c2215a115ca4795f');
+      });
+    });
+
   });
 
 

--- a/src/api/test/TransactionApi.spec.ts
+++ b/src/api/test/TransactionApi.spec.ts
@@ -31,6 +31,22 @@ describe('TransactionApi', () => {
     expect(api).to.have.property('listUnconfirmed');
   });
 
+  describe('signature check', () => {
+    it('should correctly sign a send tx', () => {
+      return api.createTransaction({
+        amount: 10,
+        passphrase: 'mysecret',
+        timestamp: 1,
+        recipientId: 'DRKaLgq8jKYQEdN2EJ7aGEh8hMDvMzd3CW',
+      }).forEach((transaction) => {
+        expect(transaction.signature).to.be.deep.eq('3045022100a3bc590b6b80b69070799ffb7fb08ecaff209f834c72a0f28c815d46eb3123b6022029c22350c72d4e42c4f39654629cd3b8d5ac377afdb338457a57bead65e83055');
+        expect(transaction.id).to.be.deep.eq('2b9debcedd717ccfe68e0786c7c3ee244ccec3181c85c709196315643350d61d');
+      });
+    });
+
+  });
+
+
   it('should create a instance of Transaction from createTransaction', () => {
     return api.createTransaction({
       amount: 100000000,

--- a/src/core/Tx.ts
+++ b/src/core/Tx.ts
@@ -13,10 +13,11 @@ import Crypto from '../utils/Crypto';
 import Slot from '../utils/Slot';
 
 function padBytes(value: string, buf: Buffer) {
-  const valBuffer = new Buffer(value);
+  const valBuffer = new Buffer(value.length>buf.length? value.substr(0,buf.length) : value);
 
-  if (valBuffer.length <= buf.length) {
-    valBuffer.copy(buf, 0);
+  valBuffer.copy(buf, 0);
+  for (let i=0; i<buf.length-valBuffer.length; i++) {
+    buf.writeInt8(0, i+valBuffer.length);
   }
 
   return buf;
@@ -91,7 +92,7 @@ export default class Tx {
    */
   public generate(): model.Transaction {
     const tx = this.transaction;
-    tx.timestamp = Slot.getTime();
+    tx.timestamp = tx.timestamp || Slot.getTime();
     tx.senderPublicKey = this.privKey.getPublicKey().toHex();
 
     if (!tx.amount) {
@@ -148,7 +149,7 @@ export default class Tx {
    */
   public toBytes(skipSignature: boolean = false, skipSecondSignature: boolean = false): Buffer {
     const tx = this.transaction;
-    const buf = new bytebuffer(undefined, true);
+    const buf = new bytebuffer(1 + 4 + 32 + 8 + 21 + 64 + 64 + 64, true);
 
     buf.writeByte(tx.type);
     buf.writeInt(tx.timestamp);
@@ -166,16 +167,12 @@ export default class Tx {
     }
 
     let padVendor = new Buffer(64);
-
-    if (tx.vendorField) {
-      padVendor = padBytes(tx.vendorField, padVendor);
-    }
+    padVendor = padBytes(tx.vendorField || '', padVendor);
 
     buf.append(padVendor);
 
     buf.writeLong(tx.amount);
     buf.writeLong(tx.fee);
-
     if (tx.asset && Object.keys(tx.asset).length > 0) {
       const asset = tx.asset[Object.keys(tx.asset)[0]];
       if (tx.type === model.TransactionType.CreateDelegate) {

--- a/src/model/Transaction.ts
+++ b/src/model/Transaction.ts
@@ -117,6 +117,9 @@ export class TransactionSend {
   @JsonProperty('vendorField')
   vendorField?: string;
 
+  @JsonProperty('timestamp')
+  timestamp?: number;
+
   constructor() {
     this.amount = void 0;
     this.passphrase = void 0;


### PR DESCRIPTION
Transaction signing was not working properly.

zeroPad function was not properly written and it was not zeropadding properly.

Besides fixing that and adding a couple of tests with manually crafted tx within ark-node, I added the ability to specify the `timestamp` field (optional) when creating a transaction.

This gives user the ability to specify its own timestamp nonce and makes testing possible.