### PR TITLE
Use correct type when getting account balance

### DIFF
--- a/src/api/AccountApi.ts
+++ b/src/api/AccountApi.ts
@@ -19,7 +19,7 @@ export default class AccountApi {
    * Get the balance of an account.
    */
   public balance(params: model.AccountQueryParams) {
-    return this.http.get<model.AccountResponse>('/accounts/getBalance', params, model.AccountResponse);
+    return this.http.get<model.AccountBalanceResponse>('/accounts/getBalance', params, model.AccountBalanceResponse);
   }
 
   /**

--- a/src/model/Account.ts
+++ b/src/model/Account.ts
@@ -60,6 +60,23 @@ export class AccountResponse {
   }
 }
 
+export class AccountBalanceResponse {
+  @JsonProperty('success')
+  success: boolean;
+
+  @JsonProperty('balance')
+  balance: string;
+
+  @JsonProperty('unconfirmedBalance')
+  unconfirmedBalance: string;
+
+  constructor() {
+    this.success = void 0;
+    this.balance = void 0;
+    this.unconfirmedBalance = void 0;
+  }
+}
+
 export class AccountVotesResponse {
   @JsonProperty('success')
   success: boolean;


### PR DESCRIPTION
Problem was that the wrong type was passed to the deserializer and therefore the values could not be set.
I think for the second call (`publicKey`) it's correct - the `publicKey` member is populated and the `account` member stays `undefined`.

fixes: #16