### PR TITLE
[Discuss] Support custom networks

### DIFF
--- a/src/api/PeerApi.ts
+++ b/src/api/PeerApi.ts
@@ -21,8 +21,17 @@ export default class PeerApi {
       http = new Http(network);
     }
     return Observable.create((observer) => {
+      if (!http.network.type) {
+        observer.error('Cannot find good peer from static peers. No NetworkType specified');
+        return;
+      }
       const networkType = model.NetworkType[http.network.type].toLowerCase();
       const peersList = config.networks[networkType].peers;
+      if (!peersList) {
+        observer.error('Cannot find good peer since there is no static peer list for the specified NetworkType.');
+        return;
+      }
+
       const loader = new LoaderApi(http);
       const blockList = [];
       let completed = false;

--- a/src/model/Network.ts
+++ b/src/model/Network.ts
@@ -4,6 +4,8 @@ import { Peer } from './Peer';
 export enum NetworkType {
   Mainnet,
   Devnet,
+  Customnet,
+  CustomDevnet
 }
 
 /** Network model. */


### PR DESCRIPTION
I create this, because the support for custom networks is not yet really there in ark-ts, but it's needed if we want to support custom networks in ark-mobile (which[ I'm implementing](https://github.com/ArkEcosystem/ark-mobile/pull/145) right now).

Discussion points:

## NetworkType
What about the `NetworkType`. Should we just omit it on custom networks or should we introduce new enum values (which I personally find cleaner). I suggest even introducing[ two values](https://github.com/ArkEcosystem/ark-ts/compare/master...Nasicus:feat/custom-networks?expand=1#diff-b6f41b3e7dee28249256f8f1ffd333f8L4). Though I'd just always use `CustomNet` at the moment,.


## FindGoodPeer method
I think most of ark-ts will work right away. One point where it breaks is the method:  [findGoodPeer](https://github.com/ArkEcosystem/ark-ts/compare/master...Nasicus:feat/custom-networks?expand=1#diff-c49d08be756b10c6b2fdc0716bdd34c5L19).
The big question is: _What is the real intention of this method?_ Because in ark-mobile we have an own [findGoodPeer](https://github.com/ArkEcosystem/ark-mobile/blob/master/src/providers/ark-api/ark-api.ts#L81) method. This method already gets a list of peers and selects the best peer based on the height and the delay. This method uses the `findGoodPeer` method of ark-ts only as a fallback and ark-ts then uses the _static peer list_ from the config file to find the best peer.

If this is really the intention of the ark-ts method we can probably just do the changes which you [see ](https://github.com/ArkEcosystem/ark-ts/pull/21/files#diff-c49d08be756b10c6b2fdc0716bdd34c5)in this PR (or should be just return null as a peer then?). However - and I know this breaks the api - I strongly recommend renaming this method then to something like `findGoodPeerFromConfig`. Because the intention of the method is really not clear.

If the intention of the method is not to just find peers based on the static list, but should just find the best peer in general, then we have to rewrite it. We could basically move the logic from ark-mobile to this class and use the static peer list only as a fallback mechanism (very similar to how ark-desktop does it).

## Peer (model)

I noticed there is not `protocol` member defined. Is this intentionally missing (because only http is supported) or should there be an enum for it (i.e. `Http` and `Https`)?