### PR TITLE
 Correct WIF byte marker for DARK addresses

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -78,7 +78,7 @@ export default {
       symbol: 'DѦ',
       version: 30,
       explorer: 'https://dexplorer.ark.io',
-      wif: 0xba,
+      wif: 0xaa,
       activePeer: {
         ip: '104.238.165.129',
         port: 4002,


### PR DESCRIPTION
Updated devnet WIF byte marker to match Ark Core.