### PR TITLE
Fix with network from constructor and not using the default

### DIFF
--- a/src/core/Tx.ts
+++ b/src/core/Tx.ts
@@ -34,12 +34,12 @@ export default class Tx {
     this.transaction = transaction;
 
     if (typeof key === 'string') {
-      key = PrivateKey.fromSeed(key);
+      key = PrivateKey.fromSeed(key,network);
     }
 
     if (secondKey) {
       if (typeof secondKey === 'string') {
-        secondKey = PrivateKey.fromSeed(secondKey);
+        secondKey = PrivateKey.fromSeed(secondKey,network);
       }
 
       this.secondPrivKey = secondKey;

--- a/src/model/Network.ts
+++ b/src/model/Network.ts
@@ -17,7 +17,8 @@ export class Network {
   public explorer: string;
   public wif?: number;
   public activePeer: Peer;
-
+  public bip32: string;
+  
   constructor() {
     // pass
   }


### PR DESCRIPTION
In my opinion, when you generate a key from seed you must use the network from the constructor otherwise it will always use the default network.
This helps the handling of multiple networks based on ARK Ecosystem.
