### PR TITLE
Remove depricated /loader/status/ping API

### DIFF
--- a/src/api/LoaderApi.ts
+++ b/src/api/LoaderApi.ts
@@ -37,12 +37,4 @@ export default class LoaderApi {
 
     return this.http.get<model.LoaderStatusSync>('/loader/status/sync', null, model.LoaderStatusSync);
   }
-
-  /**
-   * Ping the blockchain.
-   */
-  public pingStatus() {
-    return this.http.get<model.LoaderStatusPing>('/loader/status/ping', null, model.LoaderStatusPing);
-  }
-
 }

--- a/src/api/test/LoaderApi.spec.ts
+++ b/src/api/test/LoaderApi.spec.ts
@@ -62,10 +62,4 @@ describe('LoaderApi', () => {
     });
   });
 
-  it('should return sucess from pingStatus', () => {
-    return api.pingStatus().forEach((response) => {
-      expect(response).to.have.property('success', true);
-    });
-  });
-
 });

--- a/src/model/Loader.ts
+++ b/src/model/Loader.ts
@@ -84,12 +84,3 @@ export class LoaderAutoConfigure {
     this.network = void 0;
   }
 }
-
-export class LoaderStatusPing {
-  @JsonProperty('success')
-  public success: boolean;
-
-  constructor() {
-    this.success = void 0;
-  }
-}


### PR DESCRIPTION
Removed depricated /loader/status/ping API and associated model and test data.

See https://docs.ark.io/reference#api-v1-loader
