### PR TITLE
Fix: createTransction catch error

### DIFF
--- a/docs/classes/_ark_.client.html
+++ b/docs/classes/_ark_.client.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/Ark.ts#L12">Ark.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L12">Ark.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">account<span class="tsd-signature-symbol">:</span> <a href="api.accountapi.html" class="tsd-signature-type">AccountApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/Ark.ts#L7">Ark.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L7">Ark.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<span class="tsd-signature-symbol">:</span> <a href="api.blockapi.html" class="tsd-signature-type">BlockApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/Ark.ts#L11">Ark.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L11">Ark.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="api.delegateapi.html" class="tsd-signature-type">DelegateApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/Ark.ts#L8">Ark.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L8">Ark.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">loader<span class="tsd-signature-symbol">:</span> <a href="api.loaderapi.html" class="tsd-signature-type">LoaderApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/Ark.ts#L10">Ark.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L10">Ark.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <a href="api.peerapi.html" class="tsd-signature-type">PeerApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/Ark.ts#L9">Ark.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L9">Ark.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="api.transactionapi.html" class="tsd-signature-type">TransactionApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/Ark.ts#L12">Ark.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L12">Ark.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/api.accountapi.html
+++ b/docs/classes/api.accountapi.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/AccountApi.ts#L7">api/AccountApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L7">api/AccountApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/AccountApi.ts#L21">api/AccountApi.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L21">api/AccountApi.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/AccountApi.ts#L14">api/AccountApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L14">api/AccountApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/AccountApi.ts#L28">api/AccountApi.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L28">api/AccountApi.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/AccountApi.ts#L35">api/AccountApi.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L35">api/AccountApi.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.blockapi.html
+++ b/docs/classes/api.blockapi.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/BlockApi.ts#L8">api/BlockApi.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L8">api/BlockApi.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/BlockApi.ts#L36">api/BlockApi.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L36">api/BlockApi.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/BlockApi.ts#L43">api/BlockApi.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L43">api/BlockApi.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/BlockApi.ts#L50">api/BlockApi.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L50">api/BlockApi.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/BlockApi.ts#L22">api/BlockApi.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L22">api/BlockApi.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/BlockApi.ts#L29">api/BlockApi.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L29">api/BlockApi.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/BlockApi.ts#L15">api/BlockApi.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L15">api/BlockApi.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.delegateapi.html
+++ b/docs/classes/api.delegateapi.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/DelegateApi.ts#L7">api/DelegateApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L7">api/DelegateApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/DelegateApi.ts#L40">api/DelegateApi.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L40">api/DelegateApi.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/DelegateApi.ts#L14">api/DelegateApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L14">api/DelegateApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/DelegateApi.ts#L21">api/DelegateApi.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L21">api/DelegateApi.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/DelegateApi.ts#L56">api/DelegateApi.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L56">api/DelegateApi.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/DelegateApi.ts#L28">api/DelegateApi.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L28">api/DelegateApi.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.loaderapi.html
+++ b/docs/classes/api.loaderapi.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/LoaderApi.ts#L7">api/LoaderApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L7">api/LoaderApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/LoaderApi.ts#L14">api/LoaderApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L14">api/LoaderApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/LoaderApi.ts#L25">api/LoaderApi.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L25">api/LoaderApi.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/LoaderApi.ts#L32">api/LoaderApi.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L32">api/LoaderApi.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.peerapi.html
+++ b/docs/classes/api.peerapi.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/PeerApi.ts#L12">api/PeerApi.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L12">api/PeerApi.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/PeerApi.ts#L72">api/PeerApi.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L72">api/PeerApi.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/PeerApi.ts#L57">api/PeerApi.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L57">api/PeerApi.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -195,7 +195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/PeerApi.ts#L86">api/PeerApi.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L86">api/PeerApi.ts:86</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/PeerApi.ts#L65">api/PeerApi.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L65">api/PeerApi.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/PeerApi.ts#L79">api/PeerApi.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L79">api/PeerApi.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/PeerApi.ts#L19">api/PeerApi.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L19">api/PeerApi.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.transactionapi.html
+++ b/docs/classes/api.transactionapi.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L15">api/TransactionApi.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L15">api/TransactionApi.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L84">api/TransactionApi.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L90">api/TransactionApi.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L119">api/TransactionApi.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L128">api/TransactionApi.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L22">api/TransactionApi.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L22">api/TransactionApi.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -235,7 +235,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L53">api/TransactionApi.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L56">api/TransactionApi.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L162">api/TransactionApi.ts:162</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L174">api/TransactionApi.ts:174</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -291,7 +291,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L170">api/TransactionApi.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L182">api/TransactionApi.ts:182</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L178">api/TransactionApi.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L190">api/TransactionApi.ts:190</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -347,7 +347,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L185">api/TransactionApi.ts:185</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L197">api/TransactionApi.ts:197</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/api/TransactionApi.ts#L146">api/TransactionApi.ts:146</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L158">api/TransactionApi.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/core.hdnode.html
+++ b/docs/classes/core.hdnode.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.hdnode.html" class="tsd-signature-type">HDNode</a></h4>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">chain<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L19">core/HDNode.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L19">core/HDNode.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">child<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L20">core/HDNode.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L20">core/HDNode.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">depth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L21">core/HDNode.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L21">core/HDNode.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">finger<wbr>Print<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L22">core/HDNode.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L22">core/HDNode.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Private<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L23">core/HDNode.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L23">core/HDNode.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L24">core/HDNode.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L24">core/HDNode.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L25">core/HDNode.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L25">core/HDNode.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L119">core/HDNode.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L119">core/HDNode.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -248,7 +248,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L178">core/HDNode.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L178">core/HDNode.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L202">core/HDNode.ts:202</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L202">core/HDNode.ts:202</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.hdnode.html" class="tsd-signature-type">HDNode</a></h4>
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L32">core/HDNode.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L32">core/HDNode.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L115">core/HDNode.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L115">core/HDNode.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/HDNode.ts#L57">core/HDNode.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L57">core/HDNode.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.privatekey.html
+++ b/docs/classes/core.privatekey.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L66">core/Key.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L66">core/Key.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L68">core/Key.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L68">core/Key.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L111">core/Key.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L111">core/Key.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.publickey.html" class="tsd-signature-type">PublicKey</a></h4>
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L123">core/Key.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L123">core/Key.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L129">core/Key.ts:129</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L129">core/Key.ts:129</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L133">core/Key.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L133">core/Key.ts:133</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L92">core/Key.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L92">core/Key.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -257,7 +257,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L78">core/Key.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L78">core/Key.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.publickey.html
+++ b/docs/classes/core.publickey.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L9">core/Key.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L9">core/Key.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Compressed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.network.html" class="tsd-signature-type">Network</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L32">core/Key.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L32">core/Key.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L49">core/Key.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L49">core/Key.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L53">core/Key.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L53">core/Key.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L57">core/Key.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L57">core/Key.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L13">core/Key.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L13">core/Key.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L18">core/Key.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L18">core/Key.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Key.ts#L23">core/Key.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L23">core/Key.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.tx.html
+++ b/docs/classes/core.tx.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L26">core/Tx.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L26">core/Tx.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L23">core/Tx.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L23">core/Tx.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L94">core/Tx.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L94">core/Tx.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -198,7 +198,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L206">core/Tx.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L206">core/Tx.ts:206</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L234">core/Tx.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L234">core/Tx.ts:234</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L135">core/Tx.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L135">core/Tx.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L223">core/Tx.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L223">core/Tx.ts:223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L121">core/Tx.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L121">core/Tx.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -313,7 +313,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L142">core/Tx.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L142">core/Tx.ts:142</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L128">core/Tx.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L128">core/Tx.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L153">core/Tx.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L153">core/Tx.ts:153</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L213">core/Tx.ts:213</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L213">core/Tx.ts:213</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -410,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/core/Tx.ts#L56">core/Tx.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L56">core/Tx.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/model.account.html
+++ b/docs/classes/model.account.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L31">model/Account.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L31">model/Account.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.account.html" class="tsd-signature-type">Account</a></h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L7">model/Account.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L7">model/Account.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L13">model/Account.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L13">model/Account.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">multi<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L28">model/Account.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L28">model/Account.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L16">model/Account.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L16">model/Account.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L25">model/Account.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L25">model/Account.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L22">model/Account.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L22">model/Account.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">u<wbr>Multi<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L31">model/Account.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L31">model/Account.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L10">model/Account.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L10">model/Account.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L19">model/Account.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L19">model/Account.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountbalanceresponse.html
+++ b/docs/classes/model.accountbalanceresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L71">model/Account.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L71">model/Account.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountbalanceresponse.html" class="tsd-signature-type">AccountBalanceResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L68">model/Account.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L68">model/Account.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L65">model/Account.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L65">model/Account.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L71">model/Account.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L71">model/Account.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountqueryparams.html
+++ b/docs/classes/model.accountqueryparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L94">model/Account.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L94">model/Account.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountresponse.html
+++ b/docs/classes/model.accountresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L54">model/Account.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L54">model/Account.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountresponse.html" class="tsd-signature-type">AccountResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">account<span class="tsd-signature-symbol">:</span> <a href="model.account.html" class="tsd-signature-type">Account</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L51">model/Account.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L51">model/Account.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L54">model/Account.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L54">model/Account.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L48">model/Account.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L48">model/Account.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountvoter.html
+++ b/docs/classes/model.accountvoter.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountvoter.html" class="tsd-signature-type">AccountVoter</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L105">model/Delegate.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L105">model/Delegate.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L106">model/Delegate.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L106">model/Delegate.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L104">model/Delegate.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L104">model/Delegate.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountvotesresponse.html
+++ b/docs/classes/model.accountvotesresponse.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L85">model/Account.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L85">model/Account.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountvotesresponse.html" class="tsd-signature-type">AccountVotesResponse</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegates<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L85">model/Account.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L85">model/Account.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Account.ts#L82">model/Account.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L82">model/Account.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.block.html
+++ b/docs/classes/model.block.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L51">model/Block.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L51">model/Block.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.block.html" class="tsd-signature-type">Block</a></h4>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L45">model/Block.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L45">model/Block.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">confirmations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L48">model/Block.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L48">model/Block.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L42">model/Block.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L42">model/Block.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L39">model/Block.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L39">model/Block.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L15">model/Block.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L15">model/Block.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L6">model/Block.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L6">model/Block.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfTransactions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L21">model/Block.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L21">model/Block.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">payload<wbr>Hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L36">model/Block.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L36">model/Block.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">payload<wbr>Length<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L33">model/Block.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L33">model/Block.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Block<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L18">model/Block.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L18">model/Block.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">reward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L30">model/Block.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L30">model/Block.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L12">model/Block.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L12">model/Block.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L24">model/Block.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L24">model/Block.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L27">model/Block.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L27">model/Block.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Forged<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L51">model/Block.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L51">model/Block.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L9">model/Block.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L9">model/Block.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockfee.html
+++ b/docs/classes/model.blockfee.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L103">model/Block.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L103">model/Block.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockfee.html" class="tsd-signature-type">BlockFee</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L103">model/Block.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L103">model/Block.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L100">model/Block.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L100">model/Block.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockfees.html
+++ b/docs/classes/model.blockfees.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L141">model/Block.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L141">model/Block.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockfees.html" class="tsd-signature-type">BlockFees</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">fees<span class="tsd-signature-symbol">:</span> <a href="model.fees.html" class="tsd-signature-type">Fees</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L141">model/Block.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L141">model/Block.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L138">model/Block.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L138">model/Block.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockheight.html
+++ b/docs/classes/model.blockheight.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L157">model/Block.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L157">model/Block.ts:157</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockheight.html" class="tsd-signature-type">BlockHeight</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L154">model/Block.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L154">model/Block.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L157">model/Block.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L157">model/Block.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L151">model/Block.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L151">model/Block.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockqueryparams.html
+++ b/docs/classes/model.blockqueryparams.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L75">model/Block.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L75">model/Block.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L76">model/Block.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L76">model/Block.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L77">model/Block.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L77">model/Block.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L78">model/Block.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L78">model/Block.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockresponse.html
+++ b/docs/classes/model.blockresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L89">model/Block.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L89">model/Block.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockresponse.html" class="tsd-signature-type">BlockResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<span class="tsd-signature-symbol">:</span> <a href="model.block.html" class="tsd-signature-type">Block</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L89">model/Block.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L89">model/Block.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<span class="tsd-signature-symbol">:</span> <a href="model.block.html" class="tsd-signature-type">Block</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L86">model/Block.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L86">model/Block.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L83">model/Block.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L83">model/Block.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockstatus.html
+++ b/docs/classes/model.blockstatus.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L189">model/Block.ts:189</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L189">model/Block.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockstatus.html" class="tsd-signature-type">BlockStatus</a></h4>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">epoch<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Date</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L171">model/Block.ts:171</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L171">model/Block.ts:171</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L177">model/Block.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L177">model/Block.ts:177</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L174">model/Block.ts:174</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L174">model/Block.ts:174</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">milestone<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L180">model/Block.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L180">model/Block.ts:180</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L183">model/Block.ts:183</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L183">model/Block.ts:183</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">reward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L186">model/Block.ts:186</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L186">model/Block.ts:186</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L168">model/Block.ts:168</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L168">model/Block.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">supply<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L189">model/Block.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L189">model/Block.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegate.html
+++ b/docs/classes/model.delegate.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L9">model/Delegate.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L9">model/Delegate.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">approval<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L27">model/Delegate.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L27">model/Delegate.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">missed<wbr>Blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L21">model/Delegate.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L21">model/Delegate.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">produced<wbr>Blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L18">model/Delegate.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L18">model/Delegate.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">productivity<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L12">model/Delegate.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L12">model/Delegate.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L24">model/Delegate.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L24">model/Delegate.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L6">model/Delegate.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L6">model/Delegate.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L15">model/Delegate.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L15">model/Delegate.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegatequeryparams.html
+++ b/docs/classes/model.delegatequeryparams.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegatequeryparams.html" class="tsd-signature-type">DelegateQueryParams</a></h4>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L83">model/Delegate.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L83">model/Delegate.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L86">model/Delegate.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L86">model/Delegate.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L80">model/Delegate.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L80">model/Delegate.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L74">model/Delegate.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L74">model/Delegate.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L77">model/Delegate.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L77">model/Delegate.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L71">model/Delegate.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L71">model/Delegate.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">q<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L68">model/Delegate.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L68">model/Delegate.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegateresponse.html
+++ b/docs/classes/model.delegateresponse.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegateresponse.html" class="tsd-signature-type">DelegateResponse</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L53">model/Delegate.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L53">model/Delegate.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegates<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L50">model/Delegate.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L50">model/Delegate.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L47">model/Delegate.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L47">model/Delegate.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegatevoters.html
+++ b/docs/classes/model.delegatevoters.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegatevoters.html" class="tsd-signature-type">DelegateVoters</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">accounts<span class="tsd-signature-symbol">:</span> <a href="model.accountvoter.html" class="tsd-signature-type">AccountVoter</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L119">model/Delegate.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L119">model/Delegate.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.fees.html
+++ b/docs/classes/model.fees.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L125">model/Block.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L125">model/Block.ts:125</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.fees.html" class="tsd-signature-type">Fees</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L122">model/Block.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L122">model/Block.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">multisignature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L125">model/Block.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L125">model/Block.ts:125</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">secondsignature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L119">model/Block.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L119">model/Block.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">send<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L113">model/Block.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L113">model/Block.ts:113</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Block.ts#L116">model/Block.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L116">model/Block.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.forgeddetails.html
+++ b/docs/classes/model.forgeddetails.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.forgeddetails.html" class="tsd-signature-type">ForgedDetails</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">fees<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L135">model/Delegate.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L135">model/Delegate.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">forged<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">rewards<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L138">model/Delegate.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L138">model/Delegate.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Delegate.ts#L132">model/Delegate.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L132">model/Delegate.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderautoconfigure.html
+++ b/docs/classes/model.loaderautoconfigure.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderautoconfigure.html" class="tsd-signature-type">LoaderAutoConfigure</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.loadernetworkresponse.html" class="tsd-signature-type">LoaderNetworkResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L77">model/Loader.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L77">model/Loader.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loadernetworkresponse.html
+++ b/docs/classes/model.loadernetworkresponse.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loadernetworkresponse.html" class="tsd-signature-type">LoaderNetworkResponse</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">explorer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L61">model/Loader.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L61">model/Loader.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L52">model/Loader.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L52">model/Loader.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">symbol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L58">model/Loader.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L58">model/Loader.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L55">model/Loader.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L55">model/Loader.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderstatus.html
+++ b/docs/classes/model.loaderstatus.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderstatus.html" class="tsd-signature-type">LoaderStatus</a></h4>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">loaded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L9">model/Loader.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L9">model/Loader.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">now<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L12">model/Loader.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L12">model/Loader.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L6">model/Loader.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L6">model/Loader.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderstatussync.html
+++ b/docs/classes/model.loaderstatussync.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderstatussync.html" class="tsd-signature-type">LoaderStatusSync</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L33">model/Loader.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L33">model/Loader.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L36">model/Loader.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L36">model/Loader.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L27">model/Loader.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L27">model/Loader.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">syncing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Loader.ts#L30">model/Loader.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L30">model/Loader.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.network.html
+++ b/docs/classes/model.network.html
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L24">model/Network.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L24">model/Network.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.network.html" class="tsd-signature-type">Network</a></h4>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Peer<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L19">model/Network.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L19">model/Network.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L22">model/Network.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L22">model/Network.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">bip32<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L20">model/Network.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L20">model/Network.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">explorer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L17">model/Network.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L17">model/Network.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>V2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L24">model/Network.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L24">model/Network.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L12">model/Network.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L12">model/Network.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L13">model/Network.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L13">model/Network.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2p<wbr>Port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L21">model/Network.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L21">model/Network.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2p<wbr>Version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L23">model/Network.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L23">model/Network.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">symbol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L15">model/Network.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L15">model/Network.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L14">model/Network.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L14">model/Network.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NetworkType.Mainnet</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NetworkType.Devnet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L11">model/Network.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L11">model/Network.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L16">model/Network.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L16">model/Network.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">wif<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L18">model/Network.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L18">model/Network.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L81">model/Network.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L81">model/Network.ts:81</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L88">model/Network.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L88">model/Network.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -341,7 +341,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L74">model/Network.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L74">model/Network.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -369,7 +369,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L33">model/Network.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L33">model/Network.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L56">model/Network.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L56">model/Network.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/model.peer.html
+++ b/docs/classes/model.peer.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peer.html" class="tsd-signature-type">Peer</a></h4>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">delay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L18">model/Peer.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L18">model/Peer.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L6">model/Peer.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L6">model/Peer.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">os<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L15">model/Peer.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L15">model/Peer.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L9">model/Peer.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L9">model/Peer.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L21">model/Peer.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L21">model/Peer.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L12">model/Peer.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L12">model/Peer.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerqueryparams.html
+++ b/docs/classes/model.peerqueryparams.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L45">model/Peer.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L45">model/Peer.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L42">model/Peer.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L42">model/Peer.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L44">model/Peer.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L44">model/Peer.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L43">model/Peer.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L43">model/Peer.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">os<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L39">model/Peer.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L39">model/Peer.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L46">model/Peer.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L46">model/Peer.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">shared<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L40">model/Peer.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L40">model/Peer.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L38">model/Peer.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L38">model/Peer.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L41">model/Peer.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L41">model/Peer.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerresponse.html
+++ b/docs/classes/model.peerresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerresponse.html" class="tsd-signature-type">PeerResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">peers<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L54">model/Peer.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L54">model/Peer.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L51">model/Peer.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L51">model/Peer.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversion2configdataresponse.html
+++ b/docs/classes/model.peerversion2configdataresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversion2configdataresponse.html" class="tsd-signature-type">PeerVersion2ConfigDataResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L97">model/Peer.ts:97</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L97">model/Peer.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">plugins<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L94">model/Peer.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L94">model/Peer.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversion2configresponse.html
+++ b/docs/classes/model.peerversion2configresponse.html
@@ -104,7 +104,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversion2configresponse.html" class="tsd-signature-type">PeerVersion2ConfigResponse</a></h4>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <a href="model.peerversion2configdataresponse.html" class="tsd-signature-type">PeerVersion2ConfigDataResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversionresponse.html
+++ b/docs/classes/model.peerversionresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversionresponse.html" class="tsd-signature-type">PeerVersionResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">build<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L68">model/Peer.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L68">model/Peer.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Peer.ts#L71">model/Peer.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L71">model/Peer.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transaction.html
+++ b/docs/classes/model.transaction.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></h4>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L24">model/Transaction.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L24">model/Transaction.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">asset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L27">model/Transaction.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L27">model/Transaction.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L54">model/Transaction.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L54">model/Transaction.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">confirmations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L30">model/Transaction.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L30">model/Transaction.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L57">model/Transaction.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L57">model/Transaction.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L15">model/Transaction.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L15">model/Transaction.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -213,7 +213,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L21">model/Transaction.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L21">model/Transaction.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">requester<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L51">model/Transaction.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L51">model/Transaction.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -233,7 +233,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Sender<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L48">model/Transaction.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L48">model/Transaction.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -243,7 +243,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L60">model/Transaction.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L60">model/Transaction.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L45">model/Transaction.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L45">model/Transaction.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">sign<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L42">model/Transaction.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L42">model/Transaction.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 					<div class="tsd-signature tsd-kind-icon">signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L39">model/Transaction.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L39">model/Transaction.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -283,7 +283,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L18">model/Transaction.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L18">model/Transaction.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -293,7 +293,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TransactionType.SendArk</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.SecondSignature</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.CreateDelegate</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.Vote</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.MultiSignature</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L33">model/Transaction.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L33">model/Transaction.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -303,7 +303,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L36">model/Transaction.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L36">model/Transaction.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactiondelegate.html
+++ b/docs/classes/model.transactiondelegate.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactiondelegate.html" class="tsd-signature-type">TransactionDelegate</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L236">model/Transaction.ts:236</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L236">model/Transaction.ts:236</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L233">model/Transaction.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L233">model/Transaction.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L239">model/Transaction.ts:239</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L239">model/Transaction.ts:239</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L230">model/Transaction.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L230">model/Transaction.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpayload.html
+++ b/docs/classes/model.transactionpayload.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">transactions<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L195">model/Transaction.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L195">model/Transaction.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpostdataresponse.html
+++ b/docs/classes/model.transactionpostdataresponse.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionpostdataresponse.html" class="tsd-signature-type">TransactionPostDataResponse</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">accept<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L132">model/Transaction.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L132">model/Transaction.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">broadcast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">excess<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L135">model/Transaction.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L135">model/Transaction.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">invalid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L138">model/Transaction.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L138">model/Transaction.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpostresponse.html
+++ b/docs/classes/model.transactionpostresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionpostresponse.html" class="tsd-signature-type">TransactionPostResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <a href="model.transactionpostdataresponse.html" class="tsd-signature-type">TransactionPostDataResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L153">model/Transaction.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L153">model/Transaction.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<wbr>Ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L156">model/Transaction.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L156">model/Transaction.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionqueryparams.html
+++ b/docs/classes/model.transactionqueryparams.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L88">model/Transaction.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L88">model/Transaction.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L87">model/Transaction.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L87">model/Transaction.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L91">model/Transaction.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L91">model/Transaction.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L92">model/Transaction.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L92">model/Transaction.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L93">model/Transaction.ts:93</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L93">model/Transaction.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L90">model/Transaction.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L90">model/Transaction.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L89">model/Transaction.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L89">model/Transaction.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TransactionType.SendArk</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.SecondSignature</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.CreateDelegate</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.Vote</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.MultiSignature</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L94">model/Transaction.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L94">model/Transaction.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionresponse.html
+++ b/docs/classes/model.transactionresponse.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionresponse.html" class="tsd-signature-type">TransactionResponse</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L179">model/Transaction.ts:179</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L179">model/Transaction.ts:179</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L170">model/Transaction.ts:170</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L170">model/Transaction.ts:170</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L176">model/Transaction.ts:176</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L176">model/Transaction.ts:176</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">transactions<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L173">model/Transaction.ts:173</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L173">model/Transaction.ts:173</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionsend.html
+++ b/docs/classes/model.transactionsend.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionsend.html" class="tsd-signature-type">TransactionSend</a></h4>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L100">model/Transaction.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L100">model/Transaction.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L106">model/Transaction.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L106">model/Transaction.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L109">model/Transaction.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L109">model/Transaction.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L103">model/Transaction.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L103">model/Transaction.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L112">model/Transaction.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L112">model/Transaction.ts:112</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L115">model/Transaction.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L115">model/Transaction.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionvote.html
+++ b/docs/classes/model.transactionvote.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionvote.html" class="tsd-signature-type">TransactionVote</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L208">model/Transaction.ts:208</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L208">model/Transaction.ts:208</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L211">model/Transaction.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L211">model/Transaction.ts:211</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L214">model/Transaction.ts:214</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L214">model/Transaction.ts:214</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VoteType.Add</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">VoteType.Remove</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L205">model/Transaction.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L205">model/Transaction.ts:205</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/services.http.html
+++ b/docs/classes/services.http.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/Http.ts#L14">services/Http.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L14">services/Http.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.network.html" class="tsd-signature-type">Network</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/Http.ts#L16">services/Http.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L16">services/Http.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/Http.ts#L35">services/Http.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L35">services/Http.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/Http.ts#L29">services/Http.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L29">services/Http.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/Http.ts#L40">services/Http.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L40">services/Http.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -271,7 +271,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/Http.ts#L59">services/Http.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L59">services/Http.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/Http.ts#L78">services/Http.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L78">services/Http.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/services.rxrequest.html
+++ b/docs/classes/services.rxrequest.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/RxRequest.ts#L8">services/RxRequest.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L8">services/RxRequest.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">post<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/RxRequest.ts#L9">services/RxRequest.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L9">services/RxRequest.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">put<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/utils.crypto.html
+++ b/docs/classes/utils.crypto.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L78">utils/Crypto.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L78">utils/Crypto.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L85">utils/Crypto.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L85">utils/Crypto.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L51">utils/Crypto.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L51">utils/Crypto.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L47">utils/Crypto.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L47">utils/Crypto.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L61">utils/Crypto.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L61">utils/Crypto.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L31">utils/Crypto.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L31">utils/Crypto.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -256,7 +256,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L35">utils/Crypto.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L35">utils/Crypto.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L39">utils/Crypto.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L39">utils/Crypto.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -305,7 +305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L55">utils/Crypto.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L55">utils/Crypto.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -328,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L43">utils/Crypto.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L43">utils/Crypto.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L19">utils/Crypto.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L19">utils/Crypto.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -374,7 +374,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L23">utils/Crypto.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L23">utils/Crypto.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -397,7 +397,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L27">utils/Crypto.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L27">utils/Crypto.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -420,7 +420,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L65">utils/Crypto.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L65">utils/Crypto.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -443,7 +443,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Crypto.ts#L69">utils/Crypto.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L69">utils/Crypto.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/utils.slot.html
+++ b/docs/classes/utils.slot.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Slot.ts#L20">utils/Slot.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L20">utils/Slot.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Slot.ts#L49">utils/Slot.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L49">utils/Slot.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Slot.ts#L43">utils/Slot.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L43">utils/Slot.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Slot.ts#L35">utils/Slot.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L35">utils/Slot.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Slot.ts#L39">utils/Slot.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L39">utils/Slot.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Slot.ts#L10">utils/Slot.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L10">utils/Slot.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/utils/Slot.ts#L29">utils/Slot.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L29">utils/Slot.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/enums/model.networktype.html
+++ b/docs/enums/model.networktype.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Devnet<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L6">model/Network.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L6">model/Network.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mainnet<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Network.ts#L5">model/Network.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L5">model/Network.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/model.transactiontype.html
+++ b/docs/enums/model.transactiontype.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<wbr>Delegate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L7">model/Transaction.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L7">model/Transaction.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Multi<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L9">model/Transaction.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L9">model/Transaction.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Second<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L6">model/Transaction.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L6">model/Transaction.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Send<wbr>Ark<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L5">model/Transaction.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L5">model/Transaction.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L8">model/Transaction.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L8">model/Transaction.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/model.votetype.html
+++ b/docs/enums/model.votetype.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L199">model/Transaction.ts:199</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L199">model/Transaction.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/7e05cd6/src/model/Transaction.ts#L200">model/Transaction.ts:200</a></li>
+							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L200">model/Transaction.ts:200</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ark-ts",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "An ARK API wrapper, written in TypeScript to interact with ARK blockchain.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/api/TransactionApi.ts
+++ b/src/api/TransactionApi.ts
@@ -28,6 +28,9 @@ export default class TransactionApi {
 
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
+        if (!fees.send) {
+          return observer.error('Missing "send" transaction fee')
+        }
         let data = <model.Transaction> {
           amount: params.amount,
           fee: fees.send,
@@ -54,6 +57,9 @@ export default class TransactionApi {
     return Observable.create((observer: any) => {
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
+        if (!fees.vote) {
+          return observer.error('Missing "vote" transaction fee')
+        }
         const updown = model.VoteType[params.type] === 'Add' ? '+' : '-';
 
         let data = <model.Transaction> {
@@ -89,6 +95,9 @@ export default class TransactionApi {
 
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
+        if (!fees.delegate) {
+          return observer.error('Missing "delegate" transaction fee')
+        }
         let data = <model.Transaction> {
           asset: {
             delegate: {
@@ -120,6 +129,9 @@ export default class TransactionApi {
     return Observable.create((observer: any) => {
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
+        if (!fees.secondsignature) {
+          return observer.error('Missing "secondsignature" transaction fee')
+        }
         let data = <model.Transaction> {
           asset: {},
           fee: fees.secondsignature,


### PR DESCRIPTION
If fees are missing from the endpoint, it results in being unable to sign the transaction due to it being undefined. This check catches missing fees before an exception is thrown.