### PR TITLE
refactor: use axios instead of request and update mainnet config

### DIFF
--- a/docs/classes/_ark_.client.html
+++ b/docs/classes/_ark_.client.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L12">Ark.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L12">Ark.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">account<span class="tsd-signature-symbol">:</span> <a href="api.accountapi.html" class="tsd-signature-type">AccountApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L7">Ark.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L7">Ark.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<span class="tsd-signature-symbol">:</span> <a href="api.blockapi.html" class="tsd-signature-type">BlockApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L11">Ark.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L11">Ark.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="api.delegateapi.html" class="tsd-signature-type">DelegateApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L8">Ark.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L8">Ark.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">loader<span class="tsd-signature-symbol">:</span> <a href="api.loaderapi.html" class="tsd-signature-type">LoaderApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L10">Ark.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L10">Ark.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <a href="api.peerapi.html" class="tsd-signature-type">PeerApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L9">Ark.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L9">Ark.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="api.transactionapi.html" class="tsd-signature-type">TransactionApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/Ark.ts#L12">Ark.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L12">Ark.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/_ark_.client.html
+++ b/docs/classes/_ark_.client.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L12">Ark.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/Ark.ts#L12">Ark.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">account<span class="tsd-signature-symbol">:</span> <a href="api.accountapi.html" class="tsd-signature-type">AccountApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L7">Ark.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/Ark.ts#L7">Ark.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<span class="tsd-signature-symbol">:</span> <a href="api.blockapi.html" class="tsd-signature-type">BlockApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L11">Ark.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/Ark.ts#L11">Ark.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="api.delegateapi.html" class="tsd-signature-type">DelegateApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L8">Ark.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/Ark.ts#L8">Ark.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">loader<span class="tsd-signature-symbol">:</span> <a href="api.loaderapi.html" class="tsd-signature-type">LoaderApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L10">Ark.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/Ark.ts#L10">Ark.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <a href="api.peerapi.html" class="tsd-signature-type">PeerApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L9">Ark.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/Ark.ts#L9">Ark.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="api.transactionapi.html" class="tsd-signature-type">TransactionApi</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/Ark.ts#L12">Ark.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/Ark.ts#L12">Ark.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/api.accountapi.html
+++ b/docs/classes/api.accountapi.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L7">api/AccountApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/AccountApi.ts#L7">api/AccountApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L21">api/AccountApi.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/AccountApi.ts#L21">api/AccountApi.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L14">api/AccountApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/AccountApi.ts#L14">api/AccountApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L28">api/AccountApi.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/AccountApi.ts#L28">api/AccountApi.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L35">api/AccountApi.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/AccountApi.ts#L35">api/AccountApi.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.accountapi.html
+++ b/docs/classes/api.accountapi.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L7">api/AccountApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L7">api/AccountApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L21">api/AccountApi.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L21">api/AccountApi.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L14">api/AccountApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L14">api/AccountApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L28">api/AccountApi.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L28">api/AccountApi.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/AccountApi.ts#L35">api/AccountApi.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/AccountApi.ts#L35">api/AccountApi.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.blockapi.html
+++ b/docs/classes/api.blockapi.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L8">api/BlockApi.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/BlockApi.ts#L8">api/BlockApi.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L36">api/BlockApi.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/BlockApi.ts#L36">api/BlockApi.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L43">api/BlockApi.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/BlockApi.ts#L43">api/BlockApi.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L50">api/BlockApi.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/BlockApi.ts#L50">api/BlockApi.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L22">api/BlockApi.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/BlockApi.ts#L22">api/BlockApi.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L29">api/BlockApi.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/BlockApi.ts#L29">api/BlockApi.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L15">api/BlockApi.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/BlockApi.ts#L15">api/BlockApi.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.blockapi.html
+++ b/docs/classes/api.blockapi.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L8">api/BlockApi.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L8">api/BlockApi.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L36">api/BlockApi.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L36">api/BlockApi.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L43">api/BlockApi.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L43">api/BlockApi.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L50">api/BlockApi.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L50">api/BlockApi.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L22">api/BlockApi.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L22">api/BlockApi.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L29">api/BlockApi.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L29">api/BlockApi.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/BlockApi.ts#L15">api/BlockApi.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/BlockApi.ts#L15">api/BlockApi.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.delegateapi.html
+++ b/docs/classes/api.delegateapi.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L7">api/DelegateApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L7">api/DelegateApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L40">api/DelegateApi.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L40">api/DelegateApi.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L14">api/DelegateApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L14">api/DelegateApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L21">api/DelegateApi.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L21">api/DelegateApi.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L56">api/DelegateApi.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L56">api/DelegateApi.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/DelegateApi.ts#L28">api/DelegateApi.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L28">api/DelegateApi.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.delegateapi.html
+++ b/docs/classes/api.delegateapi.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L7">api/DelegateApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/DelegateApi.ts#L7">api/DelegateApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L40">api/DelegateApi.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/DelegateApi.ts#L40">api/DelegateApi.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L14">api/DelegateApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/DelegateApi.ts#L14">api/DelegateApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L21">api/DelegateApi.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/DelegateApi.ts#L21">api/DelegateApi.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L56">api/DelegateApi.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/DelegateApi.ts#L56">api/DelegateApi.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/DelegateApi.ts#L28">api/DelegateApi.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/DelegateApi.ts#L28">api/DelegateApi.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.loaderapi.html
+++ b/docs/classes/api.loaderapi.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L7">api/LoaderApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/LoaderApi.ts#L7">api/LoaderApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L14">api/LoaderApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/LoaderApi.ts#L14">api/LoaderApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L25">api/LoaderApi.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/LoaderApi.ts#L25">api/LoaderApi.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L32">api/LoaderApi.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/LoaderApi.ts#L32">api/LoaderApi.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.loaderapi.html
+++ b/docs/classes/api.loaderapi.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L7">api/LoaderApi.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L7">api/LoaderApi.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L14">api/LoaderApi.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L14">api/LoaderApi.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L25">api/LoaderApi.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L25">api/LoaderApi.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/LoaderApi.ts#L32">api/LoaderApi.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/LoaderApi.ts#L32">api/LoaderApi.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.peerapi.html
+++ b/docs/classes/api.peerapi.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L12">api/PeerApi.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/PeerApi.ts#L12">api/PeerApi.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L72">api/PeerApi.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/PeerApi.ts#L72">api/PeerApi.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L57">api/PeerApi.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/PeerApi.ts#L57">api/PeerApi.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -195,7 +195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L86">api/PeerApi.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/PeerApi.ts#L86">api/PeerApi.ts:86</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L65">api/PeerApi.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/PeerApi.ts#L65">api/PeerApi.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L79">api/PeerApi.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/PeerApi.ts#L79">api/PeerApi.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L19">api/PeerApi.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/PeerApi.ts#L19">api/PeerApi.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.peerapi.html
+++ b/docs/classes/api.peerapi.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L12">api/PeerApi.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L12">api/PeerApi.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L72">api/PeerApi.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L72">api/PeerApi.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L57">api/PeerApi.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L57">api/PeerApi.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -195,7 +195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L86">api/PeerApi.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L86">api/PeerApi.ts:86</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L65">api/PeerApi.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L65">api/PeerApi.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L79">api/PeerApi.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L79">api/PeerApi.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/PeerApi.ts#L19">api/PeerApi.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/PeerApi.ts#L19">api/PeerApi.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.transactionapi.html
+++ b/docs/classes/api.transactionapi.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L15">api/TransactionApi.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L15">api/TransactionApi.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L90">api/TransactionApi.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L90">api/TransactionApi.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L128">api/TransactionApi.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L128">api/TransactionApi.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L22">api/TransactionApi.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L22">api/TransactionApi.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -235,7 +235,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L56">api/TransactionApi.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L56">api/TransactionApi.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L174">api/TransactionApi.ts:174</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L183">api/TransactionApi.ts:183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -291,7 +291,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L182">api/TransactionApi.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L191">api/TransactionApi.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L190">api/TransactionApi.ts:190</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L199">api/TransactionApi.ts:199</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -347,7 +347,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L197">api/TransactionApi.ts:197</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L206">api/TransactionApi.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/api/TransactionApi.ts#L158">api/TransactionApi.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L157">api/TransactionApi.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/api.transactionapi.html
+++ b/docs/classes/api.transactionapi.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L15">api/TransactionApi.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L15">api/TransactionApi.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L90">api/TransactionApi.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L90">api/TransactionApi.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L128">api/TransactionApi.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L128">api/TransactionApi.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L22">api/TransactionApi.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L22">api/TransactionApi.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -235,7 +235,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L56">api/TransactionApi.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L56">api/TransactionApi.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L183">api/TransactionApi.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L183">api/TransactionApi.ts:183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -291,7 +291,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L191">api/TransactionApi.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L191">api/TransactionApi.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L199">api/TransactionApi.ts:199</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L199">api/TransactionApi.ts:199</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -347,7 +347,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L206">api/TransactionApi.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L206">api/TransactionApi.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/api/TransactionApi.ts#L157">api/TransactionApi.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/api/TransactionApi.ts#L157">api/TransactionApi.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/core.hdnode.html
+++ b/docs/classes/core.hdnode.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.hdnode.html" class="tsd-signature-type">HDNode</a></h4>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">chain<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L19">core/HDNode.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L19">core/HDNode.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">child<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L20">core/HDNode.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L20">core/HDNode.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">depth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L21">core/HDNode.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L21">core/HDNode.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">finger<wbr>Print<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L22">core/HDNode.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L22">core/HDNode.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Private<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L23">core/HDNode.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L23">core/HDNode.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L24">core/HDNode.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L24">core/HDNode.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L25">core/HDNode.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L25">core/HDNode.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L119">core/HDNode.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L119">core/HDNode.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -248,7 +248,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L178">core/HDNode.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L178">core/HDNode.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L202">core/HDNode.ts:202</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L202">core/HDNode.ts:202</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.hdnode.html" class="tsd-signature-type">HDNode</a></h4>
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L32">core/HDNode.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L32">core/HDNode.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L115">core/HDNode.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L115">core/HDNode.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/HDNode.ts#L57">core/HDNode.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L57">core/HDNode.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.hdnode.html
+++ b/docs/classes/core.hdnode.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.hdnode.html" class="tsd-signature-type">HDNode</a></h4>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">chain<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L19">core/HDNode.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L19">core/HDNode.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">child<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L20">core/HDNode.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L20">core/HDNode.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">depth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L21">core/HDNode.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L21">core/HDNode.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">finger<wbr>Print<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L22">core/HDNode.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L22">core/HDNode.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Private<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L23">core/HDNode.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L23">core/HDNode.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">key<span class="tsd-signature-symbol">:</span> <a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L24">core/HDNode.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L24">core/HDNode.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L26">core/HDNode.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L25">core/HDNode.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L25">core/HDNode.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L119">core/HDNode.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L119">core/HDNode.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -248,7 +248,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L178">core/HDNode.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L178">core/HDNode.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L202">core/HDNode.ts:202</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L202">core/HDNode.ts:202</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.hdnode.html" class="tsd-signature-type">HDNode</a></h4>
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L32">core/HDNode.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L32">core/HDNode.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L115">core/HDNode.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L115">core/HDNode.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/HDNode.ts#L57">core/HDNode.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/HDNode.ts#L57">core/HDNode.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.privatekey.html
+++ b/docs/classes/core.privatekey.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L66">core/Key.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L66">core/Key.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L68">core/Key.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L68">core/Key.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L111">core/Key.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L111">core/Key.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.publickey.html" class="tsd-signature-type">PublicKey</a></h4>
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L123">core/Key.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L123">core/Key.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L129">core/Key.ts:129</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L129">core/Key.ts:129</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L133">core/Key.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L133">core/Key.ts:133</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L92">core/Key.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L92">core/Key.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -257,7 +257,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L78">core/Key.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L78">core/Key.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.privatekey.html
+++ b/docs/classes/core.privatekey.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L66">core/Key.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L66">core/Key.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L68">core/Key.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L68">core/Key.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L111">core/Key.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L111">core/Key.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="core.publickey.html" class="tsd-signature-type">PublicKey</a></h4>
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L123">core/Key.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L123">core/Key.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L129">core/Key.ts:129</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L129">core/Key.ts:129</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L133">core/Key.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L133">core/Key.ts:133</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L92">core/Key.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L92">core/Key.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -257,7 +257,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L78">core/Key.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L78">core/Key.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.publickey.html
+++ b/docs/classes/core.publickey.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L9">core/Key.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L9">core/Key.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Compressed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.network.html" class="tsd-signature-type">Network</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L32">core/Key.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L32">core/Key.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L49">core/Key.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L49">core/Key.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L53">core/Key.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L53">core/Key.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L57">core/Key.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L57">core/Key.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L13">core/Key.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L13">core/Key.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L18">core/Key.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L18">core/Key.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L23">core/Key.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Key.ts#L23">core/Key.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.publickey.html
+++ b/docs/classes/core.publickey.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L9">core/Key.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L9">core/Key.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Buffer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Compressed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.network.html" class="tsd-signature-type">Network</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L11">core/Key.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L11">core/Key.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L32">core/Key.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L32">core/Key.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L49">core/Key.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L49">core/Key.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L53">core/Key.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L53">core/Key.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L57">core/Key.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L57">core/Key.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L13">core/Key.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L13">core/Key.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L18">core/Key.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L18">core/Key.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Key.ts#L23">core/Key.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Key.ts#L23">core/Key.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/core.tx.html
+++ b/docs/classes/core.tx.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L26">core/Tx.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L26">core/Tx.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L23">core/Tx.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L23">core/Tx.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L94">core/Tx.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L94">core/Tx.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -198,7 +198,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L206">core/Tx.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L206">core/Tx.ts:206</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L234">core/Tx.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L234">core/Tx.ts:234</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L135">core/Tx.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L135">core/Tx.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L223">core/Tx.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L223">core/Tx.ts:223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L121">core/Tx.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L121">core/Tx.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -313,7 +313,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L142">core/Tx.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L142">core/Tx.ts:142</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L128">core/Tx.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L128">core/Tx.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L153">core/Tx.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L153">core/Tx.ts:153</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L213">core/Tx.ts:213</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L213">core/Tx.ts:213</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -410,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L56">core/Tx.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/core/Tx.ts#L56">core/Tx.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/core.tx.html
+++ b/docs/classes/core.tx.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L26">core/Tx.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L26">core/Tx.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L23">core/Tx.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L23">core/Tx.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L94">core/Tx.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L94">core/Tx.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -198,7 +198,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L206">core/Tx.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L206">core/Tx.ts:206</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L234">core/Tx.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L234">core/Tx.ts:234</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L135">core/Tx.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L135">core/Tx.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L223">core/Tx.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L223">core/Tx.ts:223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L121">core/Tx.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L121">core/Tx.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -313,7 +313,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L142">core/Tx.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L142">core/Tx.ts:142</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L128">core/Tx.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L128">core/Tx.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L153">core/Tx.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L153">core/Tx.ts:153</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L213">core/Tx.ts:213</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L213">core/Tx.ts:213</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -410,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/core/Tx.ts#L56">core/Tx.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/core/Tx.ts#L56">core/Tx.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/model.account.html
+++ b/docs/classes/model.account.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L31">model/Account.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L31">model/Account.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.account.html" class="tsd-signature-type">Account</a></h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L7">model/Account.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L7">model/Account.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L13">model/Account.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L13">model/Account.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">multi<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L28">model/Account.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L28">model/Account.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L16">model/Account.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L16">model/Account.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L25">model/Account.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L25">model/Account.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L22">model/Account.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L22">model/Account.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">u<wbr>Multi<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L31">model/Account.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L31">model/Account.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L10">model/Account.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L10">model/Account.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L19">model/Account.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L19">model/Account.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.account.html
+++ b/docs/classes/model.account.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L31">model/Account.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L31">model/Account.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.account.html" class="tsd-signature-type">Account</a></h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L7">model/Account.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L7">model/Account.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L13">model/Account.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L13">model/Account.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">multi<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L28">model/Account.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L28">model/Account.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L16">model/Account.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L16">model/Account.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L25">model/Account.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L25">model/Account.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L22">model/Account.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L22">model/Account.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">u<wbr>Multi<wbr>Signatures<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L31">model/Account.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L31">model/Account.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L10">model/Account.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L10">model/Account.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L19">model/Account.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L19">model/Account.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountbalanceresponse.html
+++ b/docs/classes/model.accountbalanceresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L71">model/Account.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L71">model/Account.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountbalanceresponse.html" class="tsd-signature-type">AccountBalanceResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L68">model/Account.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L68">model/Account.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L65">model/Account.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L65">model/Account.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L71">model/Account.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L71">model/Account.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountbalanceresponse.html
+++ b/docs/classes/model.accountbalanceresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L71">model/Account.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L71">model/Account.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountbalanceresponse.html" class="tsd-signature-type">AccountBalanceResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L68">model/Account.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L68">model/Account.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L65">model/Account.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L65">model/Account.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">unconfirmed<wbr>Balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L71">model/Account.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L71">model/Account.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountqueryparams.html
+++ b/docs/classes/model.accountqueryparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L94">model/Account.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L94">model/Account.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountqueryparams.html
+++ b/docs/classes/model.accountqueryparams.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L94">model/Account.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L94">model/Account.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountresponse.html
+++ b/docs/classes/model.accountresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L54">model/Account.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L54">model/Account.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountresponse.html" class="tsd-signature-type">AccountResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">account<span class="tsd-signature-symbol">:</span> <a href="model.account.html" class="tsd-signature-type">Account</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L51">model/Account.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L51">model/Account.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L54">model/Account.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L54">model/Account.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L48">model/Account.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L48">model/Account.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountresponse.html
+++ b/docs/classes/model.accountresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L54">model/Account.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L54">model/Account.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountresponse.html" class="tsd-signature-type">AccountResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">account<span class="tsd-signature-symbol">:</span> <a href="model.account.html" class="tsd-signature-type">Account</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L51">model/Account.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L51">model/Account.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L54">model/Account.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L54">model/Account.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L48">model/Account.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L48">model/Account.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountvoter.html
+++ b/docs/classes/model.accountvoter.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountvoter.html" class="tsd-signature-type">AccountVoter</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L105">model/Delegate.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L105">model/Delegate.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L106">model/Delegate.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L106">model/Delegate.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L104">model/Delegate.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L104">model/Delegate.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountvoter.html
+++ b/docs/classes/model.accountvoter.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountvoter.html" class="tsd-signature-type">AccountVoter</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L105">model/Delegate.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L105">model/Delegate.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">balance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L107">model/Delegate.ts:107</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L106">model/Delegate.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L106">model/Delegate.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L104">model/Delegate.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L104">model/Delegate.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountvotesresponse.html
+++ b/docs/classes/model.accountvotesresponse.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L85">model/Account.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L85">model/Account.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountvotesresponse.html" class="tsd-signature-type">AccountVotesResponse</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegates<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L85">model/Account.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L85">model/Account.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L82">model/Account.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Account.ts#L82">model/Account.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.accountvotesresponse.html
+++ b/docs/classes/model.accountvotesresponse.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L85">model/Account.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L85">model/Account.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.accountvotesresponse.html" class="tsd-signature-type">AccountVotesResponse</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegates<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L85">model/Account.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L85">model/Account.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Account.ts#L82">model/Account.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Account.ts#L82">model/Account.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.block.html
+++ b/docs/classes/model.block.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L51">model/Block.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L51">model/Block.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.block.html" class="tsd-signature-type">Block</a></h4>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L45">model/Block.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L45">model/Block.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">confirmations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L48">model/Block.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L48">model/Block.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L42">model/Block.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L42">model/Block.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L39">model/Block.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L39">model/Block.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L15">model/Block.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L15">model/Block.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L6">model/Block.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L6">model/Block.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfTransactions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L21">model/Block.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L21">model/Block.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">payload<wbr>Hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L36">model/Block.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L36">model/Block.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">payload<wbr>Length<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L33">model/Block.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L33">model/Block.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Block<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L18">model/Block.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L18">model/Block.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">reward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L30">model/Block.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L30">model/Block.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L12">model/Block.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L12">model/Block.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L24">model/Block.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L24">model/Block.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L27">model/Block.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L27">model/Block.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Forged<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L51">model/Block.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L51">model/Block.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L9">model/Block.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L9">model/Block.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.block.html
+++ b/docs/classes/model.block.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L51">model/Block.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L51">model/Block.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.block.html" class="tsd-signature-type">Block</a></h4>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L45">model/Block.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L45">model/Block.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">confirmations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L48">model/Block.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L48">model/Block.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L42">model/Block.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L42">model/Block.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L39">model/Block.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L39">model/Block.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L15">model/Block.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L15">model/Block.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L6">model/Block.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L6">model/Block.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<wbr>OfTransactions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L21">model/Block.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L21">model/Block.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">payload<wbr>Hash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L36">model/Block.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L36">model/Block.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">payload<wbr>Length<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L33">model/Block.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L33">model/Block.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Block<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L18">model/Block.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L18">model/Block.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">reward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L30">model/Block.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L30">model/Block.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L12">model/Block.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L12">model/Block.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L24">model/Block.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L24">model/Block.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L27">model/Block.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L27">model/Block.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Forged<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L51">model/Block.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L51">model/Block.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L9">model/Block.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L9">model/Block.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockfee.html
+++ b/docs/classes/model.blockfee.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L103">model/Block.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L103">model/Block.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockfee.html" class="tsd-signature-type">BlockFee</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L103">model/Block.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L103">model/Block.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L100">model/Block.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L100">model/Block.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockfee.html
+++ b/docs/classes/model.blockfee.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L103">model/Block.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L103">model/Block.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockfee.html" class="tsd-signature-type">BlockFee</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L103">model/Block.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L103">model/Block.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L100">model/Block.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L100">model/Block.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockfees.html
+++ b/docs/classes/model.blockfees.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L141">model/Block.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L141">model/Block.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockfees.html" class="tsd-signature-type">BlockFees</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">fees<span class="tsd-signature-symbol">:</span> <a href="model.fees.html" class="tsd-signature-type">Fees</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L141">model/Block.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L141">model/Block.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L138">model/Block.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L138">model/Block.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockfees.html
+++ b/docs/classes/model.blockfees.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L141">model/Block.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L141">model/Block.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockfees.html" class="tsd-signature-type">BlockFees</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">fees<span class="tsd-signature-symbol">:</span> <a href="model.fees.html" class="tsd-signature-type">Fees</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L141">model/Block.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L141">model/Block.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L138">model/Block.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L138">model/Block.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockheight.html
+++ b/docs/classes/model.blockheight.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L157">model/Block.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L157">model/Block.ts:157</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockheight.html" class="tsd-signature-type">BlockHeight</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L154">model/Block.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L154">model/Block.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L157">model/Block.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L157">model/Block.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L151">model/Block.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L151">model/Block.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockheight.html
+++ b/docs/classes/model.blockheight.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L157">model/Block.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L157">model/Block.ts:157</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockheight.html" class="tsd-signature-type">BlockHeight</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L154">model/Block.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L154">model/Block.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L157">model/Block.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L157">model/Block.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L151">model/Block.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L151">model/Block.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockqueryparams.html
+++ b/docs/classes/model.blockqueryparams.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L75">model/Block.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L75">model/Block.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L76">model/Block.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L76">model/Block.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L77">model/Block.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L77">model/Block.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L78">model/Block.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L78">model/Block.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockqueryparams.html
+++ b/docs/classes/model.blockqueryparams.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L75">model/Block.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L75">model/Block.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L76">model/Block.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L76">model/Block.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L77">model/Block.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L77">model/Block.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L78">model/Block.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L78">model/Block.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockresponse.html
+++ b/docs/classes/model.blockresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L89">model/Block.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L89">model/Block.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockresponse.html" class="tsd-signature-type">BlockResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<span class="tsd-signature-symbol">:</span> <a href="model.block.html" class="tsd-signature-type">Block</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L89">model/Block.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L89">model/Block.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<span class="tsd-signature-symbol">:</span> <a href="model.block.html" class="tsd-signature-type">Block</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L86">model/Block.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L86">model/Block.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L83">model/Block.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L83">model/Block.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockresponse.html
+++ b/docs/classes/model.blockresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L89">model/Block.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L89">model/Block.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockresponse.html" class="tsd-signature-type">BlockResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<span class="tsd-signature-symbol">:</span> <a href="model.block.html" class="tsd-signature-type">Block</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L89">model/Block.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L89">model/Block.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<span class="tsd-signature-symbol">:</span> <a href="model.block.html" class="tsd-signature-type">Block</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L86">model/Block.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L86">model/Block.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L83">model/Block.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L83">model/Block.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockstatus.html
+++ b/docs/classes/model.blockstatus.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L189">model/Block.ts:189</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L189">model/Block.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockstatus.html" class="tsd-signature-type">BlockStatus</a></h4>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">epoch<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Date</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L171">model/Block.ts:171</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L171">model/Block.ts:171</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L177">model/Block.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L177">model/Block.ts:177</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L174">model/Block.ts:174</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L174">model/Block.ts:174</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">milestone<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L180">model/Block.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L180">model/Block.ts:180</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L183">model/Block.ts:183</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L183">model/Block.ts:183</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">reward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L186">model/Block.ts:186</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L186">model/Block.ts:186</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L168">model/Block.ts:168</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L168">model/Block.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">supply<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L189">model/Block.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L189">model/Block.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.blockstatus.html
+++ b/docs/classes/model.blockstatus.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L189">model/Block.ts:189</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L189">model/Block.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.blockstatus.html" class="tsd-signature-type">BlockStatus</a></h4>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">epoch<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Date</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L171">model/Block.ts:171</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L171">model/Block.ts:171</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L177">model/Block.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L177">model/Block.ts:177</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L174">model/Block.ts:174</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L174">model/Block.ts:174</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">milestone<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L180">model/Block.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L180">model/Block.ts:180</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L183">model/Block.ts:183</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L183">model/Block.ts:183</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">reward<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L186">model/Block.ts:186</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L186">model/Block.ts:186</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L168">model/Block.ts:168</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L168">model/Block.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">supply<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L189">model/Block.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L189">model/Block.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegate.html
+++ b/docs/classes/model.delegate.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L9">model/Delegate.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L9">model/Delegate.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">approval<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L27">model/Delegate.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L27">model/Delegate.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">missed<wbr>Blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L21">model/Delegate.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L21">model/Delegate.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">produced<wbr>Blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L18">model/Delegate.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L18">model/Delegate.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">productivity<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L12">model/Delegate.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L12">model/Delegate.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L24">model/Delegate.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L24">model/Delegate.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L6">model/Delegate.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L6">model/Delegate.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L15">model/Delegate.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L15">model/Delegate.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegate.html
+++ b/docs/classes/model.delegate.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L9">model/Delegate.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L9">model/Delegate.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">approval<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L27">model/Delegate.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L27">model/Delegate.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">missed<wbr>Blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L21">model/Delegate.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L21">model/Delegate.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">produced<wbr>Blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L18">model/Delegate.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L18">model/Delegate.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">productivity<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L30">model/Delegate.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L12">model/Delegate.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L12">model/Delegate.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L24">model/Delegate.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L24">model/Delegate.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L6">model/Delegate.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L6">model/Delegate.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L15">model/Delegate.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L15">model/Delegate.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegatequeryparams.html
+++ b/docs/classes/model.delegatequeryparams.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegatequeryparams.html" class="tsd-signature-type">DelegateQueryParams</a></h4>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L83">model/Delegate.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L83">model/Delegate.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L86">model/Delegate.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L86">model/Delegate.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L80">model/Delegate.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L80">model/Delegate.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L74">model/Delegate.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L74">model/Delegate.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L77">model/Delegate.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L77">model/Delegate.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L71">model/Delegate.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L71">model/Delegate.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">q<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L68">model/Delegate.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L68">model/Delegate.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegatequeryparams.html
+++ b/docs/classes/model.delegatequeryparams.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegatequeryparams.html" class="tsd-signature-type">DelegateQueryParams</a></h4>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L83">model/Delegate.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L83">model/Delegate.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">generator<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L86">model/Delegate.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L86">model/Delegate.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L80">model/Delegate.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L80">model/Delegate.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L74">model/Delegate.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L74">model/Delegate.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L77">model/Delegate.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L77">model/Delegate.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L71">model/Delegate.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L71">model/Delegate.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">q<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L89">model/Delegate.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L68">model/Delegate.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L68">model/Delegate.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegateresponse.html
+++ b/docs/classes/model.delegateresponse.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegateresponse.html" class="tsd-signature-type">DelegateResponse</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L53">model/Delegate.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L53">model/Delegate.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegates<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L50">model/Delegate.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L50">model/Delegate.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L47">model/Delegate.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L47">model/Delegate.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegateresponse.html
+++ b/docs/classes/model.delegateresponse.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegateresponse.html" class="tsd-signature-type">DelegateResponse</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L53">model/Delegate.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L53">model/Delegate.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegates<span class="tsd-signature-symbol">:</span> <a href="model.delegate.html" class="tsd-signature-type">Delegate</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L50">model/Delegate.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L50">model/Delegate.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L47">model/Delegate.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L47">model/Delegate.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">total<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L56">model/Delegate.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegatevoters.html
+++ b/docs/classes/model.delegatevoters.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegatevoters.html" class="tsd-signature-type">DelegateVoters</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">accounts<span class="tsd-signature-symbol">:</span> <a href="model.accountvoter.html" class="tsd-signature-type">AccountVoter</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L119">model/Delegate.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L119">model/Delegate.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.delegatevoters.html
+++ b/docs/classes/model.delegatevoters.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.delegatevoters.html" class="tsd-signature-type">DelegateVoters</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">accounts<span class="tsd-signature-symbol">:</span> <a href="model.accountvoter.html" class="tsd-signature-type">AccountVoter</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L122">model/Delegate.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L119">model/Delegate.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L119">model/Delegate.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.fees.html
+++ b/docs/classes/model.fees.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L125">model/Block.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L125">model/Block.ts:125</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.fees.html" class="tsd-signature-type">Fees</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L122">model/Block.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L122">model/Block.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">multisignature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L125">model/Block.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L125">model/Block.ts:125</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">secondsignature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L119">model/Block.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L119">model/Block.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">send<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L113">model/Block.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L113">model/Block.ts:113</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L116">model/Block.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Block.ts#L116">model/Block.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.fees.html
+++ b/docs/classes/model.fees.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L125">model/Block.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L125">model/Block.ts:125</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.fees.html" class="tsd-signature-type">Fees</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L122">model/Block.ts:122</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L122">model/Block.ts:122</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">multisignature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L125">model/Block.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L125">model/Block.ts:125</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">secondsignature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L119">model/Block.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L119">model/Block.ts:119</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">send<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L113">model/Block.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L113">model/Block.ts:113</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Block.ts#L116">model/Block.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Block.ts#L116">model/Block.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.forgeddetails.html
+++ b/docs/classes/model.forgeddetails.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.forgeddetails.html" class="tsd-signature-type">ForgedDetails</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">fees<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L135">model/Delegate.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L135">model/Delegate.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">forged<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">rewards<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L138">model/Delegate.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L138">model/Delegate.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L132">model/Delegate.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Delegate.ts#L132">model/Delegate.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.forgeddetails.html
+++ b/docs/classes/model.forgeddetails.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.forgeddetails.html" class="tsd-signature-type">ForgedDetails</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">fees<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L135">model/Delegate.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L135">model/Delegate.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">forged<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L141">model/Delegate.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">rewards<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L138">model/Delegate.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L138">model/Delegate.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Delegate.ts#L132">model/Delegate.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Delegate.ts#L132">model/Delegate.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderautoconfigure.html
+++ b/docs/classes/model.loaderautoconfigure.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderautoconfigure.html" class="tsd-signature-type">LoaderAutoConfigure</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.loadernetworkresponse.html" class="tsd-signature-type">LoaderNetworkResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L77">model/Loader.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L77">model/Loader.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderautoconfigure.html
+++ b/docs/classes/model.loaderautoconfigure.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderautoconfigure.html" class="tsd-signature-type">LoaderAutoConfigure</a></h4>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.loadernetworkresponse.html" class="tsd-signature-type">LoaderNetworkResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L80">model/Loader.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L77">model/Loader.ts:77</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L77">model/Loader.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loadernetworkresponse.html
+++ b/docs/classes/model.loadernetworkresponse.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loadernetworkresponse.html" class="tsd-signature-type">LoaderNetworkResponse</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">explorer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L61">model/Loader.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L61">model/Loader.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L52">model/Loader.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L52">model/Loader.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">symbol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L58">model/Loader.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L58">model/Loader.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L55">model/Loader.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L55">model/Loader.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loadernetworkresponse.html
+++ b/docs/classes/model.loadernetworkresponse.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loadernetworkresponse.html" class="tsd-signature-type">LoaderNetworkResponse</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">explorer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L61">model/Loader.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L61">model/Loader.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L52">model/Loader.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L52">model/Loader.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">symbol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L58">model/Loader.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L58">model/Loader.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L55">model/Loader.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L55">model/Loader.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L64">model/Loader.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderstatus.html
+++ b/docs/classes/model.loaderstatus.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderstatus.html" class="tsd-signature-type">LoaderStatus</a></h4>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">loaded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L9">model/Loader.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L9">model/Loader.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">now<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L12">model/Loader.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L12">model/Loader.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L6">model/Loader.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L6">model/Loader.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderstatus.html
+++ b/docs/classes/model.loaderstatus.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderstatus.html" class="tsd-signature-type">LoaderStatus</a></h4>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L15">model/Loader.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">loaded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L9">model/Loader.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L9">model/Loader.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">now<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L12">model/Loader.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L12">model/Loader.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L6">model/Loader.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L6">model/Loader.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderstatussync.html
+++ b/docs/classes/model.loaderstatussync.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderstatussync.html" class="tsd-signature-type">LoaderStatusSync</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L33">model/Loader.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L33">model/Loader.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L36">model/Loader.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L36">model/Loader.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L27">model/Loader.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L27">model/Loader.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">syncing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Loader.ts#L30">model/Loader.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L30">model/Loader.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.loaderstatussync.html
+++ b/docs/classes/model.loaderstatussync.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.loaderstatussync.html" class="tsd-signature-type">LoaderStatusSync</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">blocks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L33">model/Loader.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L33">model/Loader.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L36">model/Loader.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L36">model/Loader.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L39">model/Loader.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L27">model/Loader.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L27">model/Loader.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">syncing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Loader.ts#L30">model/Loader.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Loader.ts#L30">model/Loader.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.network.html
+++ b/docs/classes/model.network.html
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L24">model/Network.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L24">model/Network.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.network.html" class="tsd-signature-type">Network</a></h4>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Peer<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L19">model/Network.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L19">model/Network.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L22">model/Network.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L22">model/Network.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">bip32<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L20">model/Network.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L20">model/Network.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">explorer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L17">model/Network.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L17">model/Network.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>V2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L24">model/Network.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L24">model/Network.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L12">model/Network.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L12">model/Network.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L13">model/Network.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L13">model/Network.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2p<wbr>Port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L21">model/Network.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L21">model/Network.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2p<wbr>Version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L23">model/Network.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L23">model/Network.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">symbol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L15">model/Network.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L15">model/Network.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L14">model/Network.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L14">model/Network.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NetworkType.Mainnet</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NetworkType.Devnet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L11">model/Network.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L11">model/Network.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L16">model/Network.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L16">model/Network.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">wif<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L18">model/Network.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L18">model/Network.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L81">model/Network.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L81">model/Network.ts:81</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L88">model/Network.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L88">model/Network.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -341,7 +341,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L74">model/Network.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L74">model/Network.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -369,7 +369,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L33">model/Network.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L33">model/Network.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L56">model/Network.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L56">model/Network.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/model.network.html
+++ b/docs/classes/model.network.html
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L24">model/Network.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L24">model/Network.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.network.html" class="tsd-signature-type">Network</a></h4>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Peer<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L19">model/Network.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L19">model/Network.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">api<wbr>Port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L22">model/Network.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L22">model/Network.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">bip32<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L20">model/Network.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L20">model/Network.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">explorer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L17">model/Network.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L17">model/Network.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>V2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> =&nbsp;false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L24">model/Network.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L24">model/Network.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L12">model/Network.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L12">model/Network.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">nethash<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L13">model/Network.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L13">model/Network.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2p<wbr>Port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L21">model/Network.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L21">model/Network.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">p2p<wbr>Version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L23">model/Network.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L23">model/Network.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">symbol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L15">model/Network.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L15">model/Network.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L14">model/Network.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L14">model/Network.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NetworkType.Mainnet</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NetworkType.Devnet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L11">model/Network.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L11">model/Network.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L16">model/Network.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L16">model/Network.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">wif<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L18">model/Network.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L18">model/Network.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L81">model/Network.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L81">model/Network.ts:81</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L88">model/Network.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L88">model/Network.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -341,7 +341,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L74">model/Network.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L74">model/Network.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -369,7 +369,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L33">model/Network.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L33">model/Network.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L56">model/Network.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L56">model/Network.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/model.peer.html
+++ b/docs/classes/model.peer.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peer.html" class="tsd-signature-type">Peer</a></h4>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">delay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L18">model/Peer.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L18">model/Peer.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L6">model/Peer.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L6">model/Peer.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">os<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L15">model/Peer.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L15">model/Peer.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L9">model/Peer.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L9">model/Peer.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L21">model/Peer.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L21">model/Peer.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L12">model/Peer.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L12">model/Peer.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peer.html
+++ b/docs/classes/model.peer.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peer.html" class="tsd-signature-type">Peer</a></h4>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">delay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L24">model/Peer.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L18">model/Peer.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L18">model/Peer.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L6">model/Peer.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L6">model/Peer.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">os<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L15">model/Peer.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L15">model/Peer.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L9">model/Peer.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L9">model/Peer.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L21">model/Peer.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L21">model/Peer.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L12">model/Peer.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L12">model/Peer.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerqueryparams.html
+++ b/docs/classes/model.peerqueryparams.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L45">model/Peer.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L45">model/Peer.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L42">model/Peer.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L42">model/Peer.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L44">model/Peer.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L44">model/Peer.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L43">model/Peer.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L43">model/Peer.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">os<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L39">model/Peer.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L39">model/Peer.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L46">model/Peer.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L46">model/Peer.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">shared<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L40">model/Peer.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L40">model/Peer.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L38">model/Peer.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L38">model/Peer.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L41">model/Peer.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L41">model/Peer.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerqueryparams.html
+++ b/docs/classes/model.peerqueryparams.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L45">model/Peer.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L45">model/Peer.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L42">model/Peer.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L42">model/Peer.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L44">model/Peer.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L44">model/Peer.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L43">model/Peer.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L43">model/Peer.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">os<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L39">model/Peer.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L39">model/Peer.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">port<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L46">model/Peer.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L46">model/Peer.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">shared<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L40">model/Peer.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L40">model/Peer.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L38">model/Peer.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L38">model/Peer.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L41">model/Peer.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L41">model/Peer.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerresponse.html
+++ b/docs/classes/model.peerresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerresponse.html" class="tsd-signature-type">PeerResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">peers<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L54">model/Peer.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L54">model/Peer.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L51">model/Peer.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L51">model/Peer.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerresponse.html
+++ b/docs/classes/model.peerresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerresponse.html" class="tsd-signature-type">PeerResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L57">model/Peer.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">peers<span class="tsd-signature-symbol">:</span> <a href="model.peer.html" class="tsd-signature-type">Peer</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L54">model/Peer.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L54">model/Peer.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L51">model/Peer.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L51">model/Peer.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversion2configdataresponse.html
+++ b/docs/classes/model.peerversion2configdataresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversion2configdataresponse.html" class="tsd-signature-type">PeerVersion2ConfigDataResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L97">model/Peer.ts:97</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L97">model/Peer.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">plugins<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L94">model/Peer.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L94">model/Peer.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversion2configdataresponse.html
+++ b/docs/classes/model.peerversion2configdataresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversion2configdataresponse.html" class="tsd-signature-type">PeerVersion2ConfigDataResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L97">model/Peer.ts:97</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L97">model/Peer.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">plugins<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L100">model/Peer.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L94">model/Peer.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L94">model/Peer.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversion2configresponse.html
+++ b/docs/classes/model.peerversion2configresponse.html
@@ -104,7 +104,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversion2configresponse.html" class="tsd-signature-type">PeerVersion2ConfigResponse</a></h4>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <a href="model.peerversion2configdataresponse.html" class="tsd-signature-type">PeerVersion2ConfigDataResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversion2configresponse.html
+++ b/docs/classes/model.peerversion2configresponse.html
@@ -104,7 +104,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversion2configresponse.html" class="tsd-signature-type">PeerVersion2ConfigResponse</a></h4>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <a href="model.peerversion2configdataresponse.html" class="tsd-signature-type">PeerVersion2ConfigDataResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L111">model/Peer.ts:111</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversionresponse.html
+++ b/docs/classes/model.peerversionresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversionresponse.html" class="tsd-signature-type">PeerVersionResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">build<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L68">model/Peer.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L68">model/Peer.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L71">model/Peer.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Peer.ts#L71">model/Peer.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.peerversionresponse.html
+++ b/docs/classes/model.peerversionresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.peerversionresponse.html" class="tsd-signature-type">PeerVersionResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">build<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L74">model/Peer.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L68">model/Peer.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L68">model/Peer.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Peer.ts#L71">model/Peer.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Peer.ts#L71">model/Peer.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transaction.html
+++ b/docs/classes/model.transaction.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></h4>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L24">model/Transaction.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L24">model/Transaction.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">asset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L27">model/Transaction.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L27">model/Transaction.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L54">model/Transaction.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L54">model/Transaction.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">confirmations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L30">model/Transaction.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L30">model/Transaction.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L57">model/Transaction.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L57">model/Transaction.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L15">model/Transaction.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L15">model/Transaction.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -213,7 +213,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L21">model/Transaction.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L21">model/Transaction.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">requester<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L51">model/Transaction.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L51">model/Transaction.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -233,7 +233,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Sender<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L48">model/Transaction.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L48">model/Transaction.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -243,7 +243,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L60">model/Transaction.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L60">model/Transaction.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L45">model/Transaction.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L45">model/Transaction.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">sign<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L42">model/Transaction.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L42">model/Transaction.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 					<div class="tsd-signature tsd-kind-icon">signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L39">model/Transaction.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L39">model/Transaction.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -283,7 +283,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L18">model/Transaction.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L18">model/Transaction.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -293,7 +293,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TransactionType.SendArk</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.SecondSignature</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.CreateDelegate</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.Vote</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.MultiSignature</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L33">model/Transaction.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L33">model/Transaction.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -303,7 +303,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L36">model/Transaction.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L36">model/Transaction.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transaction.html
+++ b/docs/classes/model.transaction.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></h4>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L24">model/Transaction.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L24">model/Transaction.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">asset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L27">model/Transaction.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L27">model/Transaction.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L54">model/Transaction.ts:54</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L54">model/Transaction.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">confirmations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L63">model/Transaction.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">fee<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L30">model/Transaction.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L30">model/Transaction.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L57">model/Transaction.ts:57</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L57">model/Transaction.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L15">model/Transaction.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L15">model/Transaction.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -213,7 +213,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L21">model/Transaction.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L21">model/Transaction.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">requester<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L51">model/Transaction.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L51">model/Transaction.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -233,7 +233,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Sender<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L48">model/Transaction.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L48">model/Transaction.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -243,7 +243,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L60">model/Transaction.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L60">model/Transaction.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L45">model/Transaction.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L45">model/Transaction.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">sign<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L42">model/Transaction.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L42">model/Transaction.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 					<div class="tsd-signature tsd-kind-icon">signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L39">model/Transaction.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L39">model/Transaction.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -283,7 +283,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L18">model/Transaction.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L18">model/Transaction.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -293,7 +293,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TransactionType.SendArk</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.SecondSignature</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.CreateDelegate</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.Vote</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.MultiSignature</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L33">model/Transaction.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L33">model/Transaction.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -303,7 +303,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L36">model/Transaction.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L36">model/Transaction.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactiondelegate.html
+++ b/docs/classes/model.transactiondelegate.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactiondelegate.html" class="tsd-signature-type">TransactionDelegate</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L236">model/Transaction.ts:236</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L236">model/Transaction.ts:236</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L233">model/Transaction.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L233">model/Transaction.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L239">model/Transaction.ts:239</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L239">model/Transaction.ts:239</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L230">model/Transaction.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L230">model/Transaction.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactiondelegate.html
+++ b/docs/classes/model.transactiondelegate.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactiondelegate.html" class="tsd-signature-type">TransactionDelegate</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L236">model/Transaction.ts:236</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L236">model/Transaction.ts:236</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L233">model/Transaction.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L233">model/Transaction.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L239">model/Transaction.ts:239</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L239">model/Transaction.ts:239</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L230">model/Transaction.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L230">model/Transaction.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L242">model/Transaction.ts:242</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpayload.html
+++ b/docs/classes/model.transactionpayload.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">transactions<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L195">model/Transaction.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L195">model/Transaction.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpayload.html
+++ b/docs/classes/model.transactionpayload.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">transactions<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L195">model/Transaction.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L195">model/Transaction.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpostdataresponse.html
+++ b/docs/classes/model.transactionpostdataresponse.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionpostdataresponse.html" class="tsd-signature-type">TransactionPostDataResponse</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">accept<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L132">model/Transaction.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L132">model/Transaction.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">broadcast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">excess<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L135">model/Transaction.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L135">model/Transaction.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">invalid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L138">model/Transaction.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L138">model/Transaction.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpostdataresponse.html
+++ b/docs/classes/model.transactionpostdataresponse.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionpostdataresponse.html" class="tsd-signature-type">TransactionPostDataResponse</a></h4>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">accept<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L132">model/Transaction.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L132">model/Transaction.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">broadcast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L141">model/Transaction.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">excess<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L135">model/Transaction.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L135">model/Transaction.ts:135</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">invalid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L138">model/Transaction.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L138">model/Transaction.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpostresponse.html
+++ b/docs/classes/model.transactionpostresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionpostresponse.html" class="tsd-signature-type">TransactionPostResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <a href="model.transactionpostdataresponse.html" class="tsd-signature-type">TransactionPostDataResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L153">model/Transaction.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L153">model/Transaction.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<wbr>Ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L156">model/Transaction.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L156">model/Transaction.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionpostresponse.html
+++ b/docs/classes/model.transactionpostresponse.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionpostresponse.html" class="tsd-signature-type">TransactionPostResponse</a></h4>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <a href="model.transactionpostdataresponse.html" class="tsd-signature-type">TransactionPostDataResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L159">model/Transaction.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L153">model/Transaction.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L153">model/Transaction.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<wbr>Ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L156">model/Transaction.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L156">model/Transaction.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionqueryparams.html
+++ b/docs/classes/model.transactionqueryparams.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L88">model/Transaction.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L88">model/Transaction.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L87">model/Transaction.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L87">model/Transaction.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L91">model/Transaction.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L91">model/Transaction.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L92">model/Transaction.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L92">model/Transaction.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L93">model/Transaction.ts:93</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L93">model/Transaction.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L90">model/Transaction.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L90">model/Transaction.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L89">model/Transaction.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L89">model/Transaction.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TransactionType.SendArk</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.SecondSignature</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.CreateDelegate</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.Vote</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.MultiSignature</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L94">model/Transaction.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L94">model/Transaction.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionqueryparams.html
+++ b/docs/classes/model.transactionqueryparams.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">block<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L88">model/Transaction.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L88">model/Transaction.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L87">model/Transaction.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L87">model/Transaction.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L91">model/Transaction.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L91">model/Transaction.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">offset<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L92">model/Transaction.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L92">model/Transaction.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">order<wbr>By<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L93">model/Transaction.ts:93</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L93">model/Transaction.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L90">model/Transaction.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L90">model/Transaction.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L89">model/Transaction.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L89">model/Transaction.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TransactionType.SendArk</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.SecondSignature</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.CreateDelegate</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.Vote</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">TransactionType.MultiSignature</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L94">model/Transaction.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L94">model/Transaction.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionresponse.html
+++ b/docs/classes/model.transactionresponse.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionresponse.html" class="tsd-signature-type">TransactionResponse</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L179">model/Transaction.ts:179</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L179">model/Transaction.ts:179</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L170">model/Transaction.ts:170</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L170">model/Transaction.ts:170</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L176">model/Transaction.ts:176</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L176">model/Transaction.ts:176</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">transactions<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L173">model/Transaction.ts:173</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L173">model/Transaction.ts:173</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionresponse.html
+++ b/docs/classes/model.transactionresponse.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionresponse.html" class="tsd-signature-type">TransactionResponse</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L179">model/Transaction.ts:179</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L179">model/Transaction.ts:179</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L182">model/Transaction.ts:182</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">success<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L170">model/Transaction.ts:170</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L170">model/Transaction.ts:170</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">transaction<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L176">model/Transaction.ts:176</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L176">model/Transaction.ts:176</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">transactions<span class="tsd-signature-symbol">:</span> <a href="model.transaction.html" class="tsd-signature-type">Transaction</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L173">model/Transaction.ts:173</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L173">model/Transaction.ts:173</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionsend.html
+++ b/docs/classes/model.transactionsend.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionsend.html" class="tsd-signature-type">TransactionSend</a></h4>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L100">model/Transaction.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L100">model/Transaction.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L106">model/Transaction.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L106">model/Transaction.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L109">model/Transaction.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L109">model/Transaction.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L103">model/Transaction.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L103">model/Transaction.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L112">model/Transaction.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L112">model/Transaction.ts:112</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L115">model/Transaction.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L115">model/Transaction.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionsend.html
+++ b/docs/classes/model.transactionsend.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionsend.html" class="tsd-signature-type">TransactionSend</a></h4>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">amount<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L100">model/Transaction.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L100">model/Transaction.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L106">model/Transaction.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L106">model/Transaction.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L109">model/Transaction.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L109">model/Transaction.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">recipient<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L103">model/Transaction.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L103">model/Transaction.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L112">model/Transaction.ts:112</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L112">model/Transaction.ts:112</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L118">model/Transaction.ts:118</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L115">model/Transaction.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L115">model/Transaction.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionvote.html
+++ b/docs/classes/model.transactionvote.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionvote.html" class="tsd-signature-type">TransactionVote</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L208">model/Transaction.ts:208</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L208">model/Transaction.ts:208</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L211">model/Transaction.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L211">model/Transaction.ts:211</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L214">model/Transaction.ts:214</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L214">model/Transaction.ts:214</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VoteType.Add</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">VoteType.Remove</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L205">model/Transaction.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L205">model/Transaction.ts:205</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/model.transactionvote.html
+++ b/docs/classes/model.transactionvote.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="model.transactionvote.html" class="tsd-signature-type">TransactionVote</a></h4>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<wbr>Public<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L208">model/Transaction.ts:208</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L208">model/Transaction.ts:208</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L211">model/Transaction.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L211">model/Transaction.ts:211</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">second<wbr>Passphrase<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><a href="core.privatekey.html" class="tsd-signature-type">PrivateKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L214">model/Transaction.ts:214</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L214">model/Transaction.ts:214</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VoteType.Add</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">VoteType.Remove</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L205">model/Transaction.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L205">model/Transaction.ts:205</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">vendor<wbr>Field<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L217">model/Transaction.ts:217</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/services.http.html
+++ b/docs/classes/services.http.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L14">services/Http.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/Http.ts#L14">services/Http.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.network.html" class="tsd-signature-type">Network</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L16">services/Http.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/Http.ts#L16">services/Http.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L34">services/Http.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/Http.ts#L34">services/Http.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L28">services/Http.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/Http.ts#L28">services/Http.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L39">services/Http.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/Http.ts#L39">services/Http.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -271,7 +271,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L44">services/Http.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/Http.ts#L44">services/Http.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L50">services/Http.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/Http.ts#L50">services/Http.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/services.http.html
+++ b/docs/classes/services.http.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L14">services/Http.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L14">services/Http.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<span class="tsd-signature-symbol">:</span> <a href="model.network.html" class="tsd-signature-type">Network</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L16">services/Http.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L16">services/Http.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L35">services/Http.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L34">services/Http.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L29">services/Http.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L28">services/Http.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L40">services/Http.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L39">services/Http.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -265,13 +265,13 @@
 					<a name="postnative" class="tsd-anchor"></a>
 					<h3>post<wbr>Native</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter">
-						<li class="tsd-signature tsd-kind-icon">post<wbr>Native&lt;T&gt;<span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, responseType<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Observable</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">post<wbr>Native&lt;T&gt;<span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, responseType<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span>, options<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Observable</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L59">services/Http.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L44">services/Http.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -293,6 +293,9 @@
 									<ul class="tsd-parameters">
 									</ul>
 								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> options: <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> =&nbsp;{}</span></h5>
+								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Observable</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
@@ -308,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/Http.ts#L78">services/Http.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/Http.ts#L50">services/Http.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/services.rxrequest.html
+++ b/docs/classes/services.rxrequest.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L8">services/RxRequest.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/RxRequest.ts#L8">services/RxRequest.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">post<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L9">services/RxRequest.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/RxRequest.ts#L9">services/RxRequest.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">put<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/services.rxrequest.html
+++ b/docs/classes/services.rxrequest.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L8">services/RxRequest.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L8">services/RxRequest.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">post<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L9">services/RxRequest.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L9">services/RxRequest.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">put<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/services/RxRequest.ts#L10">services/RxRequest.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/utils.crypto.html
+++ b/docs/classes/utils.crypto.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L78">utils/Crypto.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L78">utils/Crypto.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L85">utils/Crypto.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L85">utils/Crypto.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L51">utils/Crypto.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L51">utils/Crypto.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L47">utils/Crypto.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L47">utils/Crypto.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L61">utils/Crypto.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L61">utils/Crypto.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L31">utils/Crypto.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L31">utils/Crypto.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -256,7 +256,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L35">utils/Crypto.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L35">utils/Crypto.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L39">utils/Crypto.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L39">utils/Crypto.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -305,7 +305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L55">utils/Crypto.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L55">utils/Crypto.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -328,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L43">utils/Crypto.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L43">utils/Crypto.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L19">utils/Crypto.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L19">utils/Crypto.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -374,7 +374,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L23">utils/Crypto.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L23">utils/Crypto.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -397,7 +397,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L27">utils/Crypto.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L27">utils/Crypto.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -420,7 +420,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L65">utils/Crypto.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L65">utils/Crypto.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -443,7 +443,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Crypto.ts#L69">utils/Crypto.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L69">utils/Crypto.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/utils.crypto.html
+++ b/docs/classes/utils.crypto.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L78">utils/Crypto.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L78">utils/Crypto.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L85">utils/Crypto.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L85">utils/Crypto.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L51">utils/Crypto.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L51">utils/Crypto.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L47">utils/Crypto.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L47">utils/Crypto.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L61">utils/Crypto.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L61">utils/Crypto.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L31">utils/Crypto.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L31">utils/Crypto.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -256,7 +256,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L35">utils/Crypto.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L35">utils/Crypto.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L39">utils/Crypto.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L39">utils/Crypto.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -305,7 +305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L55">utils/Crypto.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L55">utils/Crypto.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -328,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L43">utils/Crypto.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L43">utils/Crypto.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L19">utils/Crypto.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L19">utils/Crypto.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -374,7 +374,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L23">utils/Crypto.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L23">utils/Crypto.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -397,7 +397,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L27">utils/Crypto.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L27">utils/Crypto.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -420,7 +420,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L65">utils/Crypto.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L65">utils/Crypto.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -443,7 +443,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Crypto.ts#L69">utils/Crypto.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Crypto.ts#L69">utils/Crypto.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/utils.slot.html
+++ b/docs/classes/utils.slot.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L20">utils/Slot.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Slot.ts#L20">utils/Slot.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L49">utils/Slot.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Slot.ts#L49">utils/Slot.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L43">utils/Slot.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Slot.ts#L43">utils/Slot.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L35">utils/Slot.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Slot.ts#L35">utils/Slot.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L39">utils/Slot.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Slot.ts#L39">utils/Slot.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L10">utils/Slot.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Slot.ts#L10">utils/Slot.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L29">utils/Slot.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/utils/Slot.ts#L29">utils/Slot.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/utils.slot.html
+++ b/docs/classes/utils.slot.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L20">utils/Slot.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L20">utils/Slot.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L49">utils/Slot.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L49">utils/Slot.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L43">utils/Slot.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L43">utils/Slot.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L35">utils/Slot.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L35">utils/Slot.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L39">utils/Slot.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L39">utils/Slot.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L10">utils/Slot.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L10">utils/Slot.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/utils/Slot.ts#L29">utils/Slot.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/utils/Slot.ts#L29">utils/Slot.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/enums/model.networktype.html
+++ b/docs/enums/model.networktype.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Devnet<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L6">model/Network.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L6">model/Network.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mainnet<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L5">model/Network.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Network.ts#L5">model/Network.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/model.networktype.html
+++ b/docs/enums/model.networktype.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Devnet<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L6">model/Network.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L6">model/Network.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mainnet<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Network.ts#L5">model/Network.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Network.ts#L5">model/Network.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/model.transactiontype.html
+++ b/docs/enums/model.transactiontype.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<wbr>Delegate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L7">model/Transaction.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L7">model/Transaction.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Multi<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L9">model/Transaction.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L9">model/Transaction.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Second<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L6">model/Transaction.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L6">model/Transaction.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Send<wbr>Ark<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L5">model/Transaction.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L5">model/Transaction.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L8">model/Transaction.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L8">model/Transaction.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/model.transactiontype.html
+++ b/docs/enums/model.transactiontype.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Create<wbr>Delegate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L7">model/Transaction.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L7">model/Transaction.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Multi<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L9">model/Transaction.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L9">model/Transaction.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Second<wbr>Signature<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L6">model/Transaction.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L6">model/Transaction.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Send<wbr>Ark<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L5">model/Transaction.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L5">model/Transaction.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Vote<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> =&nbsp;3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L8">model/Transaction.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L8">model/Transaction.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/model.votetype.html
+++ b/docs/enums/model.votetype.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L199">model/Transaction.ts:199</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L199">model/Transaction.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/arkecosystem/ark-ts/blob/fd62d85/src/model/Transaction.ts#L200">model/Transaction.ts:200</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L200">model/Transaction.ts:200</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/model.votetype.html
+++ b/docs/enums/model.votetype.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Add<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L199">model/Transaction.ts:199</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L199">model/Transaction.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Remove<span class="tsd-signature-symbol">:</span> </div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/44e73be/src/model/Transaction.ts#L200">model/Transaction.ts:200</a></li>
+							<li>Defined in <a href="https://github.com/ArkEcosystem/ark-ts/blob/b2aeffb/src/model/Transaction.ts#L200">model/Transaction.ts:200</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -116,7 +116,7 @@ client.delegate.list().subscribe(<span class="hljs-function">(<span class="hljs-
 				<pre><code class="lang-bash">npm run <span class="hljs-built_in">test</span>
 </code></pre>
 				<h2 id="security">Security</h2>
-				<p>If you discover a security vulnerability within this project, please send an e-mail to <a href="mailto:security@ark.io">security@ark.io</a>. All security vulnerabilities will be promptly addressed.</p>
+				<p>If you discover a security vulnerability within this project, please send an e-mail to security@ark.io. All security vulnerabilities will be promptly addressed.</p>
 				<h2 id="contributing">Contributing</h2>
 				<ul>
 					<li>If you find any bugs, submit an <a href="../../issues">issue</a> or open <a href="../../pulls">pull-request</a>, helping us catch and fix them.</li>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^8.0.12",
     "@types/request": "^2.0.0",
     "@types/rx": "^4.1.1",
+    "axios": "^0.18.0",
     "bigi": "^1.4.2",
     "bs58check": "^2.0.2",
     "bytebuffer": "^5.0.1",
@@ -42,7 +43,6 @@
     "ecurve": "^1.0.5",
     "json-typescript-mapper": "^1.1.3",
     "randombytes": "^2.0.5",
-    "request": "^2.81.0",
     "rxjs": "^5.4.2",
     "secp256k1": "^3.3.0",
     "wif": "^2.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ark-ts",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "An ARK API wrapper, written in TypeScript to interact with ARK blockchain.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/api/TransactionApi.ts
+++ b/src/api/TransactionApi.ts
@@ -156,15 +156,25 @@ export default class TransactionApi {
    */
   public post(transaction: model.Transaction, peer?: Peer) {
     const params = {transactions: [transaction]};
+    const host = peer ? peer.ip : this.http.network.activePeer.ip;
+    const endpoint = '/peer/transactions';
 
-    if (peer) {
-      const port = this.http.network.isV2 ? this.http.network.p2pPort : peer.port;
-      let url = `http://${peer.ip}:${port}/peer/transactions`;
+    let port = peer ? peer.port : this.http.network.activePeer.port;
 
-      return this.http.postNative<model.TransactionPostResponse>(url, params, model.TransactionPostResponse);
+    if (this.http.network.isV2) {
+      port = this.http.network.p2pPort;
     }
 
-    return this.http.post<model.TransactionPostResponse>('/peer/transactions', params, model.TransactionPostResponse);
+    const options = {
+      headers: {
+        nethash: this.http.network.nethash,
+        port,
+        version: this.http.network.p2pVersion || ''
+      }
+    };
+
+    const url = `http://${host}:${port}${endpoint}`;
+    return this.http.postNative<model.TransactionPostResponse>(url, params, model.TransactionPostResponse, options);
   }
 
   /**

--- a/src/api/TransactionApi.ts
+++ b/src/api/TransactionApi.ts
@@ -29,7 +29,7 @@ export default class TransactionApi {
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
         if (!fees.send) {
-          return observer.error('Missing "send" transaction fee')
+          return observer.error('Missing "send" transaction fee');
         }
         let data = <model.Transaction> {
           amount: params.amount,
@@ -58,7 +58,7 @@ export default class TransactionApi {
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
         if (!fees.vote) {
-          return observer.error('Missing "vote" transaction fee')
+          return observer.error('Missing "vote" transaction fee');
         }
         const updown = model.VoteType[params.type] === 'Add' ? '+' : '-';
 
@@ -96,7 +96,7 @@ export default class TransactionApi {
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
         if (!fees.delegate) {
-          return observer.error('Missing "delegate" transaction fee')
+          return observer.error('Missing "delegate" transaction fee');
         }
         let data = <model.Transaction> {
           asset: {
@@ -130,7 +130,7 @@ export default class TransactionApi {
       BlockApi.networkFees(this.http.network).subscribe((blocks) => {
         const fees = blocks.fees;
         if (!fees.secondsignature) {
-          return observer.error('Missing "secondsignature" transaction fee')
+          return observer.error('Missing "secondsignature" transaction fee');
         }
         let data = <model.Transaction> {};
         data.asset = {};
@@ -169,8 +169,8 @@ export default class TransactionApi {
       headers: {
         nethash: this.http.network.nethash,
         port,
-        version: this.http.network.p2pVersion || ''
-      }
+        version: this.http.network.p2pVersion || '',
+      },
     };
 
     const url = `http://${host}:${port}${endpoint}`;

--- a/src/api/test/TransactionApi.spec.ts
+++ b/src/api/test/TransactionApi.spec.ts
@@ -9,6 +9,9 @@ import { Transaction, TransactionType, VoteType, TransactionVote, TransactionDel
 import { expect } from 'chai';
 import { PrivateKey } from '../../index';
 
+import 'rxjs/add/operator/take'
+import 'rxjs/add/operator/toPromise'
+
 /* tslint:disable:no-unused-expression */
 const network = Network.getDefault(NetworkType.Devnet);
 const http = new Http(network);
@@ -207,9 +210,10 @@ describe('TransactionApi', () => {
     };
 
     return api.post(transaction).forEach((response) => {
+      console.log(response)
       if (network.isV2) {
         expect(response).to.have.property('transactionIds');
-        expect(response.transactionIds).to.be.an('array').that.does.not.include(transaction.id);
+        expect(response.transactionIds).to.be.undefined;
       } else {
         expect(response).to.have.property('success', false);
       }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,10 +14,13 @@ export default {
       version: 0x17,
       explorer: 'https://explorer.ark.io',
       wif: 0xaa,
-      p2pVersion: '1.1.0',
+      p2pPort: 4002,
+      apiPort: 4003,
+      p2pVersion: '2.0.0',
+      isV2: true,
       activePeer: {
-        ip: 'node1.arknet.cloud',
-        port: 4001,
+        ip: '167.114.29.51',
+        port: 4003,
       },
       peers: [
         '5.39.9.240:4001',

--- a/src/core/Tx.ts
+++ b/src/core/Tx.ts
@@ -34,12 +34,12 @@ export default class Tx {
     this.transaction = transaction;
 
     if (typeof key === 'string') {
-      key = PrivateKey.fromSeed(key,network);
+      key = PrivateKey.fromSeed(key, network);
     }
 
     if (secondKey) {
       if (typeof secondKey === 'string') {
-        secondKey = PrivateKey.fromSeed(secondKey,network);
+        secondKey = PrivateKey.fromSeed(secondKey, network);
       }
 
       this.secondPrivKey = secondKey;

--- a/src/model/Peer.ts
+++ b/src/model/Peer.ts
@@ -86,18 +86,18 @@ const genericConverter: ICustomConverter = {
   },
   toJson(data: any): any {
     return JSON.stringify(data);
-  }
+  },
 };
 
 export class PeerVersion2ConfigDataResponse {
   @JsonProperty('version')
-  version: string;
+  public version: string;
 
   @JsonProperty({customConverter: genericConverter, name: 'network'})
-  network?: object;
+  public network?: object;
 
   @JsonProperty({customConverter: genericConverter, name: 'plugins'})
-  plugins?: object;
+  public plugins?: object;
 
   constructor() {
     this.version = void 0;
@@ -108,7 +108,7 @@ export class PeerVersion2ConfigDataResponse {
 
 export class PeerVersion2ConfigResponse {
   @JsonProperty({clazz: PeerVersion2ConfigDataResponse, name: 'data'})
-  data: PeerVersion2ConfigDataResponse;
+  public data: PeerVersion2ConfigDataResponse;
 
   constructor() {
     this.data = void 0;

--- a/src/model/Transaction.ts
+++ b/src/model/Transaction.ts
@@ -129,16 +129,16 @@ export class TransactionSend {
 
 export class TransactionPostDataResponse {
   @JsonProperty('accept')
-  accept: string[];
+  public accept: string[];
 
   @JsonProperty('excess')
-  excess: string[];
+  public excess: string[];
 
   @JsonProperty('invalid')
-  invalid: string[];
+  public invalid: string[];
 
   @JsonProperty('broadcast')
-  broadcast: string[];
+  public broadcast: string[];
 
   constructor() {
     this.accept = void 0;
@@ -156,7 +156,7 @@ export class TransactionPostResponse {
   public transactionIds: string[];
 
   @JsonProperty({clazz: TransactionPostDataResponse, name: 'data'})
-  data: TransactionPostDataResponse;
+  public data: TransactionPostDataResponse;
 
   constructor() {
     this.success = void 0;

--- a/src/model/Transaction.ts
+++ b/src/model/Transaction.ts
@@ -158,10 +158,14 @@ export class TransactionPostResponse {
   @JsonProperty({clazz: TransactionPostDataResponse, name: 'data'})
   public data: TransactionPostDataResponse;
 
+  @JsonProperty('error')
+  public error: string;
+
   constructor() {
     this.success = void 0;
     this.transactionIds = void 0;
     this.data = void 0;
+    this.error = void 0;
   }
 }
 

--- a/src/services/Http.ts
+++ b/src/services/Http.ts
@@ -11,7 +11,7 @@ import * as model from '../model';
 export default class Http {
 
   private baseRequest;
-  private timeout = 6000
+  private timeout = 6000;
 
   public constructor(public network?: model.Network) {
     const options = {
@@ -42,7 +42,6 @@ export default class Http {
   }
 
   public postNative<T>(url: string, body: any, responseType?: new() => T, options: any = {}): Observable<T> {
-    console.log(options)
     const r = new RxRequest(options);
 
     return r.post(url, body).map((data) => this.formatResponse(data, responseType));

--- a/src/services/Http.ts
+++ b/src/services/Http.ts
@@ -11,23 +11,22 @@ import * as model from '../model';
 export default class Http {
 
   private baseRequest;
-  private timeout = 3000
+  private timeout = 6000
 
   public constructor(public network?: model.Network) {
     const options = {
-      json: true,
       timeout: this.timeout,
     };
 
     if (network) {
-      options['baseUrl'] = network.getPeerAPIUrl();
+      options['baseURL'] = network.getPeerAPIUrl();
     }
 
     this.baseRequest = new RxRequest(options);
   }
 
   public getNative<T>(url: string, params: any = {}, responseType?: new() => T): Observable<T> {
-    const r = new RxRequest({ json: true, timeout: this.timeout });
+    const r = new RxRequest({ timeout: this.timeout });
 
     return r.get(url, this.formatParams(params)).map((data) => this.formatResponse(data, responseType));
   }
@@ -38,46 +37,20 @@ export default class Http {
   }
 
   public post<T>(url: string, body: any, responseType?: new() => T): Observable<T> {
-    const options = {
-      body,
-      json: true,
-    };
-
-    if (/^\/peer/.test(url)) {
-      options['baseUrl'] = this.network.getPeerP2PUrl();
-      options['headers'] = {
-        nethash: this.network.nethash,
-        port: this.network.activePeer.port,
-        version: this.network.p2pVersion,
-      };
-    }
-
-    return this.baseRequest.post(url, options)
+    return this.baseRequest.post(url, body)
                            .map((data) => this.formatResponse(data, responseType));
   }
 
-  public postNative<T>(url: string, body: any, responseType?: new() => T): Observable<T> {
-    const options = {
-      body,
-      json: true,
-    }
-
-    if (/:\d+\/peer/.test(url)) {
-      options['headers'] = {
-        nethash: this.network.nethash,
-        port: this.network.activePeer.port,
-        version: this.network.p2pVersion,
-      };
-    }
-
+  public postNative<T>(url: string, body: any, responseType?: new() => T, options: any = {}): Observable<T> {
+    console.log(options)
     const r = new RxRequest(options);
 
-    return r.post(url).map((data) => this.formatResponse(data, responseType));
+    return r.post(url, body).map((data) => this.formatResponse(data, responseType));
   }
 
   public put(url: string, data: any) {
     const options = {
-      json: data,
+      data,
     };
 
     return this.baseRequest.put(url, options);
@@ -105,7 +78,7 @@ export default class Http {
   private formatParams(params: any): any {
     const options = JSON.parse(JSON.stringify(params) || '{}');
 
-    return { qs: options };
+    return { params: options };
   }
 
 }

--- a/src/services/RxRequest.ts
+++ b/src/services/RxRequest.ts
@@ -1,45 +1,52 @@
-import { Observable } from 'rxjs';
-import * as request from 'request';
+import { Observable } from 'rxjs/Observable';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosPromise } from 'axios';
 
 /** Based on @waldojeffers/rx-request. */
 export class RxRequest {
 
-  private req: request.RequestAPI<request.Request, request.CoreOptions, request.RequiredUriUrl>;
+  private req: AxiosInstance;
   public get;
   public post;
   public put;
 
   constructor(options: any) {
-    this.req = request.defaults(options);
+    const headers = {
+      ...options.headers,
+      'Content-Type': 'application/json'
+    }
+
+    this.req = axios.create({
+      ...options,
+      headers
+    })
 
     this.get = this.toObservable(this.req.get);
     this.post = this.toObservable(this.req.post);
     this.put = this.toObservable(this.req.put);
   }
 
-  private toObservable(method: any): (url: string, options: request.CoreOptions) => Observable<any> {
+  private toObservable(method: any): (url: string, AxiosRequestConfig) => Observable<any> {
 
-    return (url: string, options: request.CoreOptions): Observable<any> => {
+    return (url: string, options: AxiosRequestConfig): Observable<any> => {
       return Observable.create((observer) => {
-        let body = '';
-
         method(url, options)
-          .on('response', function onResponse(res) {
-            res.setEncoding('utf8');
-            if (res.statusCode < 200 || res.statusCode >= 300) {
-              this.emit('error', {
+          .then(res => {
+            console.log(res);
+            if (res.status < 200 || res.status >= 300) {
+              observer.error({
                 statusCode: res.statusCode,
                 statusMessage: res.statusMessage,
               });
+            } else {
+              observer.next(res.data);
+              observer.complete();
             }
           })
-
-          .on('error', (e) => observer.error(e))
-          .on('data', (chunk) => body += chunk)
-          .on('end', () => {
-            observer.next(body);
+          .catch(err => {
+            console.error(err);
+            observer.error(err);
             observer.complete();
-          });
+          })
       });
     };
   }

--- a/src/services/RxRequest.ts
+++ b/src/services/RxRequest.ts
@@ -12,13 +12,13 @@ export class RxRequest {
   constructor(options: any) {
     const headers = {
       ...options.headers,
-      'Content-Type': 'application/json'
-    }
+      'Content-Type': 'application/json',
+    };
 
     this.req = axios.create({
       ...options,
-      headers
-    })
+      headers,
+    });
 
     this.get = this.toObservable(this.req.get);
     this.post = this.toObservable(this.req.post);
@@ -30,8 +30,7 @@ export class RxRequest {
     return (url: string, options: AxiosRequestConfig): Observable<any> => {
       return Observable.create((observer) => {
         method(url, options)
-          .then(res => {
-            console.log(res);
+          .then((res) => {
             if (res.status < 200 || res.status >= 300) {
               observer.error({
                 statusCode: res.statusCode,
@@ -42,11 +41,10 @@ export class RxRequest {
               observer.complete();
             }
           })
-          .catch(err => {
-            console.error(err);
+          .catch((err) => {
             observer.error(err);
             observer.complete();
-          })
+          });
       });
     };
   }

--- a/src/services/RxRequest.ts
+++ b/src/services/RxRequest.ts
@@ -33,8 +33,7 @@ export class RxRequest {
           .then((res) => {
             if (res.status < 200 || res.status >= 300) {
               observer.error({
-                statusCode: res.statusCode,
-                statusMessage: res.statusMessage,
+                ...res.data
               });
             } else {
               observer.next(res.data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,13 +151,6 @@
   dependencies:
     "@types/node" "*"
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -199,18 +192,6 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asn1@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-
 assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
@@ -219,17 +200,12 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
-
-aws4@^1.2.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -248,12 +224,6 @@ base-x@^3.0.2:
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.2.tgz#bf873861b7514279b7969f340929eab87c11d130"
   dependencies:
     safe-buffer "^5.0.1"
-
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
-  dependencies:
-    tweetnacl "^0.14.3"
 
 bigi@^1.1.0, bigi@^1.4.2:
   version "1.4.2"
@@ -278,12 +248,6 @@ bl@^1.0.0:
 bn.js@^4.11.3, bn.js@^4.4.0:
   version "4.11.7"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"
-
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  dependencies:
-    hoek "2.x.x"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -336,10 +300,6 @@ bytebuffer@^5.0.1:
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -400,10 +360,6 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -421,12 +377,6 @@ color-name@^1.1.1:
 colors@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-
-combined-stream@^1.0.5, combined-stream@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
-  dependencies:
-    delayed-stream "~1.0.0"
 
 commander@2.9.0:
   version "2.9.0"
@@ -470,23 +420,17 @@ create-hmac@^1.1.4, create-hmac@^1.1.6:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  dependencies:
-    boom "2.x.x"
-
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  dependencies:
-    assert-plus "^1.0.0"
-
 debug@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.0.0:
   version "1.2.0"
@@ -501,10 +445,6 @@ deep-eql@^2.0.1:
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -525,12 +465,6 @@ drbg.js@^1.0.1:
     browserify-aes "^1.0.6"
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
-
-ecc-jsbn@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
-  dependencies:
-    jsbn "~0.1.0"
 
 ecurve@^1.0.5:
   version "1.0.5"
@@ -578,25 +512,11 @@ expand-template@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.0.3.tgz#6c303323177a62b1b22c070279f7861287b69b1a"
 
-extend@~3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
-
-extsprintf@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
-
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+follow-redirects@^1.3.0:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
   dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
+    debug "=3.1.0"
 
 fs-extra@^4.0.0:
   version "4.0.1"
@@ -626,12 +546,6 @@ gauge@~2.7.3:
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  dependencies:
-    assert-plus "^1.0.0"
 
 github-from-package@0.0.0:
   version "0.0.0"
@@ -681,17 +595,6 @@ handlebars@^4.0.6:
   optionalDependencies:
     uglify-js "^2.6"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -723,15 +626,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
 highlight.js@^9.0.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
@@ -743,18 +637,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -785,39 +667,13 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
-is-typedarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  dependencies:
-    jsonify "~0.0.0"
-
-json-stringify-safe@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
 json-typescript-mapper@^1.1.3:
   version "1.1.3"
@@ -834,19 +690,6 @@ jsonfile@^3.0.0:
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsprim@^1.2.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.0.2"
-    json-schema "0.2.3"
-    verror "1.3.6"
 
 kind-of@^3.0.2:
   version "3.2.2"
@@ -925,16 +768,6 @@ marked@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
-mime-db@~1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
-
-mime-types@^2.1.12, mime-types@~2.1.7:
-  version "2.1.16"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
-  dependencies:
-    mime-db "~1.29.0"
-
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -987,6 +820,10 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 nan@^2.2.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
@@ -1011,10 +848,6 @@ npmlog@^4.0.1:
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-
-oauth-sign@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
 object-assign@^4.1.0:
   version "4.1.1"
@@ -1049,10 +882,6 @@ pathval@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-
 prebuild-install@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.2.0.tgz#55934756a32bac8747390ca44ff663cee8b99b69"
@@ -1086,14 +915,6 @@ pump@^1.0.0, pump@^1.0.1:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
-
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 randombytes@^2.0.5:
   version "2.0.5"
@@ -1135,33 +956,6 @@ reflect-metadata@^0.1.3:
 repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-
-request@^2.81.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
 
 resolve@^1.1.6:
   version "1.3.3"
@@ -1254,12 +1048,6 @@ simple-get@^1.4.2:
     unzip-response "^1.0.0"
     xtend "^4.0.0"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  dependencies:
-    hoek "2.x.x"
-
 source-map-support@^0.4.0, source-map-support@^0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
@@ -1276,20 +1064,6 @@ source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-sshpk@^1.7.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    dashdash "^1.12.0"
-    getpass "^0.1.1"
-  optionalDependencies:
-    bcrypt-pbkdf "^1.0.0"
-    ecc-jsbn "~0.1.1"
-    jsbn "~0.1.0"
-    tweetnacl "~0.14.0"
-
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -1303,10 +1077,6 @@ string_decoder@~1.0.3:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
     safe-buffer "~5.1.0"
-
-stringstream@~0.0.4:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -1360,12 +1130,6 @@ tar-stream@^1.1.2:
     readable-stream "^2.0.0"
     xtend "^4.0.0"
 
-tough-cookie@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
-  dependencies:
-    punycode "^1.4.1"
-
 ts-node@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.3.0.tgz#c13c6a3024e30be1180dd53038fc209289d4bf69"
@@ -1418,10 +1182,6 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
-
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
 type-detect@^3.0.0:
   version "3.0.0"
@@ -1498,21 +1258,11 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
 v8flags@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.0.tgz#4be9604488e0c4123645def705b1848d16b8e01f"
   dependencies:
     user-home "^1.1.1"
-
-verror@1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
-  dependencies:
-    extsprintf "1.0.2"
 
 wide-align@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
Since core has added the cors headers, the request library does not seem to handle preflight requests properly. So I switched to axios.

@alexbarnsley Look at the first commit, the second is just documentation stuff.