### PR TITLE
fix: fetch peer configuration frow the new endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ark-ts",
-  "version": "0.3.16",
+  "version": "0.3.18",
   "description": "An ARK API wrapper, written in TypeScript to interact with ARK blockchain.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/api/PeerApi.ts
+++ b/src/api/PeerApi.ts
@@ -84,7 +84,20 @@ export default class PeerApi {
    * Get config for version 2 peers.
    */
   public getVersion2Config(ip: string, p2pPort: number): Observable<model.PeerVersion2ConfigResponse> {
-    return this.http.getNative<model.PeerVersion2ConfigResponse>(
-        `http://${ip}:${p2pPort}/config`, null, model.PeerVersion2ConfigResponse);
+    return Observable.create((observer) => {
+      this.http.getNative<model.PeerVersion2ConfigResponse>(
+        `http://${ip}:4040`, null, model.PeerVersion2ConfigResponse).subscribe((response) => {
+          observer.next(response)
+          observer.complete()
+        }, () => {
+          this.http.getNative<model.PeerVersion2ConfigResponse>(
+            `http://${ip}:${p2pPort}/config`, null, model.PeerVersion2ConfigResponse).subscribe((response) => {
+              observer.next(response)
+              observer.complete()
+            }, (e) => {
+              observer.error(e)
+            })
+        })
+    })
   }
 }


### PR DESCRIPTION
## Proposed changes

The `/config` endpoint has been removed, now the port `:4040` must be used

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)